### PR TITLE
M3: Query Editor — Monaco, streaming execution, IntelliSense

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ssmsx",
       "version": "0.1.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-virtual": "^3.13.23",
         "@tauri-apps/api": "^2",
@@ -768,6 +769,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1474,6 +1498,14 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1602,6 +1634,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2032,6 +2074,30 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2209,6 +2275,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-virtual": "^3.13.23",
     "@tauri-apps/api": "^2",

--- a/sidecar/src/Ssmsx.Core/Query/IntelliSenseService.cs
+++ b/sidecar/src/Ssmsx.Core/Query/IntelliSenseService.cs
@@ -1,0 +1,180 @@
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using Microsoft.Data.SqlClient;
+using Ssmsx.Core.Connections;
+using Ssmsx.Protocol.Messages;
+
+namespace Ssmsx.Core.Query;
+
+public partial class IntelliSenseService
+{
+    private readonly ConnectionManager _connectionManager;
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _connectionLocks = new();
+
+    /// <summary>
+    /// Default command timeout in seconds for IntelliSense metadata queries.
+    /// Kept low to avoid blocking the UI for unresponsive databases.
+    /// </summary>
+    private const int DefaultCommandTimeoutSeconds = 10;
+
+    public IntelliSenseService(ConnectionManager connectionManager)
+    {
+        _connectionManager = connectionManager;
+    }
+
+    private SemaphoreSlim GetConnectionLock(string connectionId)
+    {
+        return _connectionLocks.GetOrAdd(connectionId, _ => new SemaphoreSlim(1, 1));
+    }
+
+    [GeneratedRegex(@"^[a-zA-Z0-9_ .\-]+$")]
+    private static partial Regex SafeNameRegex();
+
+    private static void ValidateDatabaseName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Database name cannot be empty");
+        if (!SafeNameRegex().IsMatch(name))
+            throw new ArgumentException($"Invalid database name: {name}");
+    }
+
+    public async Task<IntelliSenseMetadata> GetMetadataAsync(string connectionId, string database, CancellationToken ct = default)
+    {
+        ValidateDatabaseName(database);
+        var semaphore = GetConnectionLock(connectionId);
+        await semaphore.WaitAsync(ct);
+        try
+        {
+            var connection = _connectionManager.GetConnection(connectionId);
+            var originalDb = connection.Database;
+            try
+            {
+                connection.ChangeDatabase(database);
+
+                var tables = await GetTablesAndViewsAsync(connection, ct);
+                var columns = await GetColumnsAsync(connection, ct);
+                var procedures = await GetProceduresAsync(connection, ct);
+                var functions = await GetFunctionsAsync(connection, ct);
+
+                return new IntelliSenseMetadata
+                {
+                    Tables = tables,
+                    Columns = columns,
+                    Procedures = procedures,
+                    Functions = functions
+                };
+            }
+            finally
+            {
+                if (!string.IsNullOrEmpty(originalDb))
+                    connection.ChangeDatabase(originalDb);
+            }
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }
+
+    private static async Task<List<IntelliSenseTable>> GetTablesAndViewsAsync(SqlConnection connection, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+            FROM INFORMATION_SCHEMA.TABLES
+            ORDER BY TABLE_SCHEMA, TABLE_NAME
+            """;
+
+        await using var cmd = new SqlCommand(sql, connection) { CommandTimeout = DefaultCommandTimeoutSeconds };
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        var results = new List<IntelliSenseTable>();
+        while (await reader.ReadAsync(ct))
+        {
+            var tableType = reader.GetString(2);
+            results.Add(new IntelliSenseTable
+            {
+                Schema = reader.GetString(0),
+                Name = reader.GetString(1),
+                Type = tableType == "BASE TABLE" ? "table" : "view"
+            });
+        }
+        return results;
+    }
+
+    private static async Task<List<IntelliSenseColumn>> GetColumnsAsync(SqlConnection connection, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE
+            FROM INFORMATION_SCHEMA.COLUMNS
+            ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION
+            """;
+
+        await using var cmd = new SqlCommand(sql, connection) { CommandTimeout = DefaultCommandTimeoutSeconds };
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        var results = new List<IntelliSenseColumn>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new IntelliSenseColumn
+            {
+                Schema = reader.GetString(0),
+                TableName = reader.GetString(1),
+                Name = reader.GetString(2),
+                DataType = reader.GetString(3)
+            });
+        }
+        return results;
+    }
+
+    private static async Task<List<IntelliSenseProcedure>> GetProceduresAsync(SqlConnection connection, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT s.name AS [schema], p.name
+            FROM sys.procedures p
+            JOIN sys.schemas s ON p.schema_id = s.schema_id
+            ORDER BY s.name, p.name
+            """;
+
+        await using var cmd = new SqlCommand(sql, connection) { CommandTimeout = DefaultCommandTimeoutSeconds };
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        var results = new List<IntelliSenseProcedure>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new IntelliSenseProcedure
+            {
+                Schema = reader.GetString(0),
+                Name = reader.GetString(1)
+            });
+        }
+        return results;
+    }
+
+    private static async Task<List<IntelliSenseFunction>> GetFunctionsAsync(SqlConnection connection, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT s.name AS [schema], o.name,
+                   CASE o.type
+                       WHEN 'FN' THEN 'scalar'
+                       WHEN 'IF' THEN 'inline'
+                       WHEN 'TF' THEN 'table'
+                       ELSE o.type
+                   END AS function_type
+            FROM sys.objects o
+            JOIN sys.schemas s ON o.schema_id = s.schema_id
+            WHERE o.type IN ('FN', 'IF', 'TF')
+            ORDER BY s.name, o.name
+            """;
+
+        await using var cmd = new SqlCommand(sql, connection) { CommandTimeout = DefaultCommandTimeoutSeconds };
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        var results = new List<IntelliSenseFunction>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new IntelliSenseFunction
+            {
+                Schema = reader.GetString(0),
+                Name = reader.GetString(1),
+                Type = reader.GetString(2)
+            });
+        }
+        return results;
+    }
+}

--- a/sidecar/src/Ssmsx.Core/Query/QueryCancellationManager.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryCancellationManager.cs
@@ -1,0 +1,105 @@
+using System.Collections.Concurrent;
+using Microsoft.Data.SqlClient;
+
+namespace Ssmsx.Core.Query;
+
+/// <summary>
+/// Manages cancellation tokens and SQL commands for active queries,
+/// enabling cooperative cancellation of in-flight query executions.
+/// </summary>
+public class QueryCancellationManager
+{
+    private readonly ConcurrentDictionary<string, (CancellationTokenSource Cts, SqlCommand? Cmd)> _activeQueries = new();
+
+    /// <summary>
+    /// Registers a new query with its cancellation token source.
+    /// </summary>
+    /// <param name="queryId">The unique identifier for the query.</param>
+    /// <param name="cts">The cancellation token source to associate with this query.</param>
+    /// <exception cref="ArgumentException">Thrown when queryId is null or empty.</exception>
+    public void Register(string queryId, CancellationTokenSource cts)
+    {
+        if (string.IsNullOrWhiteSpace(queryId))
+            throw new ArgumentException("Query ID cannot be null or empty.", nameof(queryId));
+        ArgumentNullException.ThrowIfNull(cts);
+
+        _activeQueries[queryId] = (cts, null);
+    }
+
+    /// <summary>
+    /// Associates a SqlCommand with an already-registered query,
+    /// enabling SqlCommand.Cancel() for immediate server-side cancellation.
+    /// </summary>
+    /// <param name="queryId">The unique identifier for the query.</param>
+    /// <param name="cmd">The SqlCommand to associate.</param>
+    public void SetCommand(string queryId, SqlCommand cmd)
+    {
+        if (string.IsNullOrWhiteSpace(queryId))
+            throw new ArgumentException("Query ID cannot be null or empty.", nameof(queryId));
+        ArgumentNullException.ThrowIfNull(cmd);
+
+        if (_activeQueries.TryGetValue(queryId, out var entry))
+        {
+            _activeQueries[queryId] = (entry.Cts, cmd);
+        }
+    }
+
+    /// <summary>
+    /// Cancels an active query by triggering the CancellationTokenSource
+    /// and calling SqlCommand.Cancel() if a command is associated.
+    /// Returns true if the query was found and cancellation was initiated.
+    /// </summary>
+    /// <param name="queryId">The unique identifier for the query to cancel.</param>
+    /// <returns>True if cancellation was initiated; false if the query was not found.</returns>
+    public bool Cancel(string queryId)
+    {
+        if (string.IsNullOrWhiteSpace(queryId))
+            return false;
+
+        if (!_activeQueries.TryRemove(queryId, out var entry))
+            return false;
+
+        try
+        {
+            entry.Cts.Cancel();
+        }
+        catch (ObjectDisposedException ex)
+        {
+            Console.Error.WriteLine($"Warning: CancellationTokenSource for query '{queryId}' was already disposed: {ex.Message}");
+        }
+
+        try
+        {
+            entry.Cmd?.Cancel();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Warning: Failed to cancel SqlCommand for query '{queryId}': {ex.Message}");
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Removes a query from tracking after it has completed (successfully or otherwise).
+    /// Disposes the CancellationTokenSource.
+    /// </summary>
+    /// <param name="queryId">The unique identifier for the query to remove.</param>
+    public void Remove(string queryId)
+    {
+        if (string.IsNullOrWhiteSpace(queryId))
+            return;
+
+        if (_activeQueries.TryRemove(queryId, out var entry))
+        {
+            try
+            {
+                entry.Cts.Dispose();
+            }
+            catch (ObjectDisposedException ex)
+            {
+                Console.Error.WriteLine($"Warning: CancellationTokenSource for query '{queryId}' was already disposed during cleanup: {ex.Message}");
+            }
+        }
+    }
+}

--- a/sidecar/src/Ssmsx.Core/Query/QueryCancellationManager.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryCancellationManager.cs
@@ -9,7 +9,7 @@ namespace Ssmsx.Core.Query;
 /// </summary>
 public class QueryCancellationManager
 {
-    private readonly ConcurrentDictionary<string, (CancellationTokenSource Cts, SqlCommand? Cmd)> _activeQueries = new();
+    private readonly ConcurrentDictionary<string, QueryState> _activeQueries = new();
 
     /// <summary>
     /// Registers a new query with its cancellation token source.
@@ -23,12 +23,14 @@ public class QueryCancellationManager
             throw new ArgumentException("Query ID cannot be null or empty.", nameof(queryId));
         ArgumentNullException.ThrowIfNull(cts);
 
-        _activeQueries[queryId] = (cts, null);
+        _activeQueries[queryId] = new QueryState(cts);
     }
 
     /// <summary>
     /// Associates a SqlCommand with an already-registered query,
     /// enabling SqlCommand.Cancel() for immediate server-side cancellation.
+    /// If a cancel was requested before this command was registered, cancels
+    /// the command immediately so the caller's blocking read is interrupted.
     /// </summary>
     /// <param name="queryId">The unique identifier for the query.</param>
     /// <param name="cmd">The SqlCommand to associate.</param>
@@ -40,13 +42,30 @@ public class QueryCancellationManager
 
         if (_activeQueries.TryGetValue(queryId, out var entry))
         {
-            _activeQueries[queryId] = (entry.Cts, cmd);
+            entry.Cmd = cmd;
+
+            // If Cancel() was called before the command was registered, we stored
+            // the intent in Cancelled — apply it now so the query is interrupted
+            // immediately rather than silently running to completion.
+            if (entry.Cancelled)
+            {
+                try
+                {
+                    cmd.Cancel();
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Warning: Failed to cancel late-registered SqlCommand for query '{queryId}': {ex.Message}");
+                }
+            }
         }
     }
 
     /// <summary>
     /// Cancels an active query by triggering the CancellationTokenSource
     /// and calling SqlCommand.Cancel() if a command is associated.
+    /// If the command hasn't been registered yet, marks the entry so
+    /// SetCommand will cancel the command as soon as it arrives.
     /// Returns true if the query was found and cancellation was initiated.
     /// </summary>
     /// <param name="queryId">The unique identifier for the query to cancel.</param>
@@ -56,8 +75,13 @@ public class QueryCancellationManager
         if (string.IsNullOrWhiteSpace(queryId))
             return false;
 
-        if (!_activeQueries.TryRemove(queryId, out var entry))
+        // Don't remove the entry — SetCommand may still be racing to register the
+        // command. Mark Cancelled so a late SetCommand cancels immediately. The
+        // entry is cleaned up by Remove() when the query actually finishes.
+        if (!_activeQueries.TryGetValue(queryId, out var entry))
             return false;
+
+        entry.Cancelled = true;
 
         try
         {
@@ -100,6 +124,23 @@ public class QueryCancellationManager
             {
                 Console.Error.WriteLine($"Warning: CancellationTokenSource for query '{queryId}' was already disposed during cleanup: {ex.Message}");
             }
+        }
+    }
+
+    private sealed class QueryState
+    {
+        public CancellationTokenSource Cts { get; }
+        public SqlCommand? Cmd { get; set; }
+
+        /// <summary>
+        /// Set to true when Cancel() was called. If the SqlCommand arrives
+        /// after this, SetCommand will cancel it immediately.
+        /// </summary>
+        public bool Cancelled { get; set; }
+
+        public QueryState(CancellationTokenSource cts)
+        {
+            Cts = cts;
         }
     }
 }

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -235,7 +235,7 @@ public class QueryExecutor
             {
                 Name = reader.GetName(i),
                 DataType = reader.GetDataTypeName(i),
-                IsNullable = reader.IsDBNull(i) || true, // We can't reliably check schema here; default to nullable
+                IsNullable = true, // Default to nullable; enriched by schema table below
                 MaxLength = null
             };
             columns.Add(column);

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -283,6 +283,8 @@ public class QueryExecutor
 
     /// <summary>
     /// Reads a single row from the SqlDataReader, converting values to JSON-safe types.
+    /// UDT columns (geography, geometry, hierarchyid) are read as raw bytes to avoid
+    /// loading Microsoft.SqlServer.Types which we don't ship.
     /// </summary>
     private static List<object?> ReadRow(SqlDataReader reader)
     {
@@ -295,10 +297,65 @@ public class QueryExecutor
                 continue;
             }
 
-            var value = reader.GetValue(i);
-            row.Add(ConvertToJsonSafeValue(value));
+            // Check for UDT types that need Microsoft.SqlServer.Types assembly
+            // and read them as raw bytes instead of trying to instantiate the CLR type.
+            var typeName = reader.GetDataTypeName(i);
+            if (IsUnsupportedUdt(typeName))
+            {
+                row.Add(ReadUdtAsBytes(reader, i));
+                continue;
+            }
+
+            try
+            {
+                var value = reader.GetValue(i);
+                row.Add(ConvertToJsonSafeValue(value));
+            }
+            catch (Exception ex) when (IsAssemblyLoadError(ex))
+            {
+                // Fallback: the CLR type wasn't recognized ahead of time but needs an
+                // assembly we don't have. Read as bytes instead.
+                row.Add(ReadUdtAsBytes(reader, i));
+            }
         }
         return row;
+    }
+
+    private static bool IsUnsupportedUdt(string dataTypeName)
+    {
+        // Match fully-qualified names like "sys.geography" or short "geography"
+        var name = dataTypeName.Split('.').Last().ToLowerInvariant();
+        return name is "geography" or "geometry" or "hierarchyid";
+    }
+
+    private static bool IsAssemblyLoadError(Exception ex)
+    {
+        // Walks inner exceptions looking for FileNotFoundException on SqlServer.Types,
+        // which is what gets thrown when GetValue() tries to instantiate a spatial type
+        // without the assembly available.
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            if (e is System.IO.FileNotFoundException || e is System.IO.FileLoadException)
+                return true;
+            if (e.Message.Contains("Microsoft.SqlServer.Types", StringComparison.Ordinal))
+                return true;
+        }
+        return false;
+    }
+
+    private static object? ReadUdtAsBytes(SqlDataReader reader, int i)
+    {
+        try
+        {
+            var sqlBytes = reader.GetSqlBytes(i);
+            if (sqlBytes.IsNull)
+                return null;
+            return "0x" + Convert.ToHexString(sqlBytes.Value);
+        }
+        catch (Exception ex)
+        {
+            return $"<unreadable UDT: {ex.Message}>";
+        }
     }
 
     /// <summary>

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -1,3 +1,4 @@
+using System.Data.SqlTypes;
 using System.Diagnostics;
 using Microsoft.Data.SqlClient;
 using Ssmsx.Core.Connections;
@@ -302,22 +303,63 @@ public class QueryExecutor
 
     /// <summary>
     /// Converts a SQL value to a JSON-safe representation.
-    /// Binary data is converted to base64, dates to ISO 8601, etc.
+    /// All values are converted to types registered in ProtocolJsonContext:
+    /// null, string, bool, byte, short, int, long, float, double, decimal.
+    ///
+    /// SQL Server type → CLR type from GetValue() → JSON-safe output:
+    ///   bigint          → Int64          → long (kept)
+    ///   int             → Int32          → int (kept)
+    ///   smallint        → Int16          → short (kept)
+    ///   tinyint         → Byte           → byte (kept)
+    ///   bit             → Boolean        → bool (kept)
+    ///   decimal/numeric → Decimal        → decimal (kept)
+    ///   money/smallmoney→ Decimal        → decimal (kept)
+    ///   float           → Double         → double (kept)
+    ///   real            → Single         → float (kept)
+    ///   char/nchar/varchar/nvarchar/text/ntext → String → string (kept)
+    ///   date/datetime/datetime2/smalldatetime  → DateTime → string (ISO 8601)
+    ///   datetimeoffset  → DateTimeOffset → string (ISO 8601)
+    ///   time            → TimeSpan       → string (hh:mm:ss.fffffff)
+    ///   uniqueidentifier→ Guid           → string
+    ///   binary/varbinary/image/rowversion/timestamp → Byte[] → string (base64)
+    ///   xml             → SqlXml         → string (XML content)
+    ///   sql_variant     → Object         → recursive (underlying type)
     /// </summary>
     private static object? ConvertToJsonSafeValue(object value)
     {
         return value switch
         {
+            // Null
             DBNull => null,
+
+            // Numeric types — kept as-is (registered in ProtocolJsonContext)
+            bool b => b,
+            byte b => b,
+            short s => s,
+            int i => i,
+            long l => l,
+            float f => f,
+            double d => d,
+            decimal m => m,
+
+            // String types — kept as-is
+            string s => s,
+
+            // Binary types → base64 string
             byte[] bytes => Convert.ToBase64String(bytes),
+
+            // Date/time types → ISO 8601 string
             DateTime dt => dt.ToString("O"),
             DateTimeOffset dto => dto.ToString("O"),
-            TimeSpan ts => ts.ToString(),
+            TimeSpan ts => ts.ToString("c"), // constant format: hh:mm:ss.fffffff
+
+            // Guid → string
             Guid guid => guid.ToString(),
-            decimal d => d,
-            float f => f,
-            double dbl => dbl,
-            int or long or short or byte or bool => value,
+
+            // SqlXml (from SQL xml type) → XML content string
+            SqlXml xml => xml.IsNull ? null : xml.Value,
+
+            // Fallback for any unexpected type (e.g. SqlTypes wrappers) → string
             _ => value.ToString()
         };
     }

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -1,0 +1,324 @@
+using System.Diagnostics;
+using Microsoft.Data.SqlClient;
+using Ssmsx.Core.Connections;
+using Ssmsx.Protocol.Messages;
+using Ssmsx.Protocol.Models;
+
+namespace Ssmsx.Core.Query;
+
+/// <summary>
+/// Executes SQL queries against active connections, streaming results in batches
+/// and supporting cooperative cancellation.
+/// </summary>
+public class QueryExecutor
+{
+    private readonly ConnectionManager _connectionManager;
+    private readonly QueryCancellationManager _cancellationManager;
+
+    /// <summary>
+    /// The number of rows to include in each streamed batch.
+    /// </summary>
+    private const int BatchSize = 5000;
+
+    /// <summary>
+    /// Default command timeout in seconds. Zero means no timeout (queries can run indefinitely,
+    /// cancellation is handled via the CancellationToken and QueryCancellationManager).
+    /// </summary>
+    private const int DefaultCommandTimeoutSeconds = 0;
+
+    public QueryExecutor(ConnectionManager connectionManager, QueryCancellationManager cancellationManager)
+    {
+        _connectionManager = connectionManager ?? throw new ArgumentNullException(nameof(connectionManager));
+        _cancellationManager = cancellationManager ?? throw new ArgumentNullException(nameof(cancellationManager));
+    }
+
+    /// <summary>
+    /// Executes a SQL query, streaming result batches via the onBatch callback.
+    /// Supports multiple result sets and cooperative cancellation.
+    /// </summary>
+    /// <param name="connectionId">The ID of the active connection to use.</param>
+    /// <param name="database">The database context to execute the query against.</param>
+    /// <param name="sql">The SQL text to execute.</param>
+    /// <param name="queryId">A unique identifier for this query execution.</param>
+    /// <param name="onBatch">Callback invoked for each batch of results.</param>
+    /// <param name="ct">Cancellation token for cooperative cancellation.</param>
+    public async Task ExecuteAsync(
+        string connectionId,
+        string database,
+        string sql,
+        string queryId,
+        Func<QueryExecuteResult, Task> onBatch,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(connectionId))
+            throw new ArgumentException("Connection ID cannot be null or empty.", nameof(connectionId));
+        if (string.IsNullOrWhiteSpace(database))
+            throw new ArgumentException("Database cannot be null or empty.", nameof(database));
+        if (string.IsNullOrWhiteSpace(sql))
+            throw new ArgumentException("SQL cannot be null or empty.", nameof(sql));
+        if (string.IsNullOrWhiteSpace(queryId))
+            throw new ArgumentException("Query ID cannot be null or empty.", nameof(queryId));
+        ArgumentNullException.ThrowIfNull(onBatch);
+
+        var connection = _connectionManager.GetConnection(connectionId);
+        var messages = new List<QueryMessage>();
+        var stopwatch = new Stopwatch();
+        long totalRows = 0;
+        int batchNumber = 0;
+
+        // Hook into InfoMessage for PRINT statements and non-fatal errors
+        SqlInfoMessageEventHandler infoMessageHandler = (sender, args) =>
+        {
+            foreach (SqlError error in args.Errors)
+            {
+                var severity = error.Class > 10 ? "error" : "info";
+                messages.Add(new QueryMessage
+                {
+                    Text = error.Message,
+                    Severity = severity,
+                    LineNumber = error.LineNumber > 0 ? error.LineNumber : null
+                });
+            }
+        };
+
+        connection.InfoMessage += infoMessageHandler;
+        try
+        {
+            connection.ChangeDatabase(database);
+
+            await using var cmd = new SqlCommand(sql, connection)
+            {
+                CommandTimeout = DefaultCommandTimeoutSeconds
+            };
+
+            _cancellationManager.SetCommand(queryId, cmd);
+
+            stopwatch.Start();
+
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+            int resultSetIndex = 0;
+
+            do
+            {
+                // Read column metadata for this result set
+                var columns = ReadColumnMetadata(reader);
+                bool isFirstBatchForResultSet = true;
+
+                var rowBuffer = new List<List<object?>>();
+
+                while (await reader.ReadAsync(ct))
+                {
+                    var row = ReadRow(reader);
+                    rowBuffer.Add(row);
+                    totalRows++;
+
+                    if (rowBuffer.Count >= BatchSize)
+                    {
+                        batchNumber++;
+                        var batch = new QueryExecuteResult
+                        {
+                            QueryId = queryId,
+                            Columns = isFirstBatchForResultSet ? columns : null,
+                            Rows = rowBuffer,
+                            Batch = batchNumber,
+                            Done = false,
+                            ResultSetIndex = resultSetIndex
+                        };
+
+                        await onBatch(batch);
+                        rowBuffer = new List<List<object?>>();
+                        isFirstBatchForResultSet = false;
+                    }
+                }
+
+                // Send remaining rows for this result set (or an empty batch with columns if no rows)
+                if (rowBuffer.Count > 0 || isFirstBatchForResultSet)
+                {
+                    batchNumber++;
+                    var batch = new QueryExecuteResult
+                    {
+                        QueryId = queryId,
+                        Columns = isFirstBatchForResultSet ? columns : null,
+                        Rows = rowBuffer.Count > 0 ? rowBuffer : null,
+                        Batch = batchNumber,
+                        Done = false,
+                        ResultSetIndex = resultSetIndex
+                    };
+
+                    await onBatch(batch);
+                }
+
+                resultSetIndex++;
+            }
+            while (await reader.NextResultAsync(ct));
+
+            stopwatch.Stop();
+
+            // Send final "done" batch
+            batchNumber++;
+            var finalBatch = new QueryExecuteResult
+            {
+                QueryId = queryId,
+                Batch = batchNumber,
+                Done = true,
+                ExecutionTimeMs = stopwatch.ElapsedMilliseconds,
+                TotalRows = totalRows,
+                Messages = messages.Count > 0 ? messages : null
+            };
+
+            await onBatch(finalBatch);
+        }
+        catch (OperationCanceledException)
+        {
+            stopwatch.Stop();
+
+            messages.Add(new QueryMessage
+            {
+                Text = "Query execution was cancelled by the user.",
+                Severity = "info"
+            });
+
+            batchNumber++;
+            var cancelledBatch = new QueryExecuteResult
+            {
+                QueryId = queryId,
+                Batch = batchNumber,
+                Done = true,
+                ExecutionTimeMs = stopwatch.ElapsedMilliseconds,
+                TotalRows = totalRows,
+                Messages = messages.Count > 0 ? messages : null
+            };
+
+            await onBatch(cancelledBatch);
+        }
+        catch (SqlException ex) when (ex.Number == 0 && ex.Message.Contains("Operation cancelled"))
+        {
+            // SqlCommand.Cancel() can throw SqlException with this pattern
+            stopwatch.Stop();
+
+            messages.Add(new QueryMessage
+            {
+                Text = "Query execution was cancelled by the user.",
+                Severity = "info"
+            });
+
+            batchNumber++;
+            var cancelledBatch = new QueryExecuteResult
+            {
+                QueryId = queryId,
+                Batch = batchNumber,
+                Done = true,
+                ExecutionTimeMs = stopwatch.ElapsedMilliseconds,
+                TotalRows = totalRows,
+                Messages = messages.Count > 0 ? messages : null
+            };
+
+            await onBatch(cancelledBatch);
+        }
+        finally
+        {
+            connection.InfoMessage -= infoMessageHandler;
+            _cancellationManager.Remove(queryId);
+        }
+    }
+
+    /// <summary>
+    /// Reads column metadata from the current result set of a SqlDataReader.
+    /// </summary>
+    private static List<QueryColumn> ReadColumnMetadata(SqlDataReader reader)
+    {
+        var columns = new List<QueryColumn>();
+        for (int i = 0; i < reader.FieldCount; i++)
+        {
+            var column = new QueryColumn
+            {
+                Name = reader.GetName(i),
+                DataType = reader.GetDataTypeName(i),
+                IsNullable = reader.IsDBNull(i) || true, // We can't reliably check schema here; default to nullable
+                MaxLength = null
+            };
+            columns.Add(column);
+        }
+
+        // Try to get richer schema info if available
+        try
+        {
+            var schemaTable = reader.GetSchemaTable();
+            if (schemaTable is not null)
+            {
+                for (int i = 0; i < columns.Count && i < schemaTable.Rows.Count; i++)
+                {
+                    var schemaRow = schemaTable.Rows[i];
+
+                    bool isNullable = columns[i].IsNullable;
+                    if (schemaTable.Columns.Contains("AllowDBNull") && schemaRow["AllowDBNull"] is bool allowNull)
+                    {
+                        isNullable = allowNull;
+                    }
+
+                    int? maxLength = null;
+                    if (schemaTable.Columns.Contains("ColumnSize") && schemaRow["ColumnSize"] is int colSize && colSize > 0)
+                    {
+                        maxLength = colSize;
+                    }
+
+                    columns[i] = columns[i] with
+                    {
+                        IsNullable = isNullable,
+                        MaxLength = maxLength
+                    };
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Schema table is optional enrichment — log but don't fail the query
+            Console.Error.WriteLine($"Warning: Could not read schema table for column metadata: {ex.Message}");
+        }
+
+        return columns;
+    }
+
+    /// <summary>
+    /// Reads a single row from the SqlDataReader, converting values to JSON-safe types.
+    /// </summary>
+    private static List<object?> ReadRow(SqlDataReader reader)
+    {
+        var row = new List<object?>(reader.FieldCount);
+        for (int i = 0; i < reader.FieldCount; i++)
+        {
+            if (reader.IsDBNull(i))
+            {
+                row.Add(null);
+                continue;
+            }
+
+            var value = reader.GetValue(i);
+            row.Add(ConvertToJsonSafeValue(value));
+        }
+        return row;
+    }
+
+    /// <summary>
+    /// Converts a SQL value to a JSON-safe representation.
+    /// Binary data is converted to base64, dates to ISO 8601, etc.
+    /// </summary>
+    private static object? ConvertToJsonSafeValue(object value)
+    {
+        return value switch
+        {
+            DBNull => null,
+            byte[] bytes => Convert.ToBase64String(bytes),
+            DateTime dt => dt.ToString("O"),
+            DateTimeOffset dto => dto.ToString("O"),
+            TimeSpan ts => ts.ToString(),
+            Guid guid => guid.ToString(),
+            decimal d => d,
+            float f => f,
+            double dbl => dbl,
+            int or long or short or byte or bool => value,
+            _ => value.ToString()
+        };
+    }
+}

--- a/sidecar/src/Ssmsx.Protocol/Messages/IntelliSenseMessages.cs
+++ b/sidecar/src/Ssmsx.Protocol/Messages/IntelliSenseMessages.cs
@@ -1,0 +1,43 @@
+namespace Ssmsx.Protocol.Messages;
+
+public record IntelliSenseGetMetadataParams
+{
+    public required string ConnectionId { get; init; }
+    public required string Database { get; init; }
+}
+
+public record IntelliSenseMetadata
+{
+    public required List<IntelliSenseTable> Tables { get; init; }
+    public required List<IntelliSenseColumn> Columns { get; init; }
+    public required List<IntelliSenseProcedure> Procedures { get; init; }
+    public required List<IntelliSenseFunction> Functions { get; init; }
+}
+
+public record IntelliSenseTable
+{
+    public required string Schema { get; init; }
+    public required string Name { get; init; }
+    public required string Type { get; init; } // "table" or "view"
+}
+
+public record IntelliSenseColumn
+{
+    public required string Schema { get; init; }
+    public required string TableName { get; init; }
+    public required string Name { get; init; }
+    public required string DataType { get; init; }
+}
+
+public record IntelliSenseProcedure
+{
+    public required string Schema { get; init; }
+    public required string Name { get; init; }
+}
+
+public record IntelliSenseFunction
+{
+    public required string Schema { get; init; }
+    public required string Name { get; init; }
+    public required string Type { get; init; } // "scalar", "table", "inline"
+}

--- a/sidecar/src/Ssmsx.Protocol/Messages/QueryMessages.cs
+++ b/sidecar/src/Ssmsx.Protocol/Messages/QueryMessages.cs
@@ -1,0 +1,58 @@
+using System.Text.Json.Serialization;
+using Ssmsx.Protocol.Models;
+
+namespace Ssmsx.Protocol.Messages;
+
+public record QueryExecuteParams
+{
+    [JsonPropertyName("connectionId")]
+    public required string ConnectionId { get; init; }
+
+    [JsonPropertyName("database")]
+    public required string Database { get; init; }
+
+    [JsonPropertyName("sql")]
+    public required string Sql { get; init; }
+}
+
+public record QueryCancelParams
+{
+    [JsonPropertyName("queryId")]
+    public required string QueryId { get; init; }
+}
+
+public record QueryExecuteResult
+{
+    [JsonPropertyName("queryId")]
+    public required string QueryId { get; init; }
+
+    [JsonPropertyName("columns")]
+    public List<QueryColumn>? Columns { get; init; }
+
+    [JsonPropertyName("rows")]
+    public List<List<object?>>? Rows { get; init; }
+
+    [JsonPropertyName("batch")]
+    public int Batch { get; init; }
+
+    [JsonPropertyName("done")]
+    public bool Done { get; init; }
+
+    [JsonPropertyName("executionTimeMs")]
+    public long? ExecutionTimeMs { get; init; }
+
+    [JsonPropertyName("totalRows")]
+    public long? TotalRows { get; init; }
+
+    [JsonPropertyName("messages")]
+    public List<QueryMessage>? Messages { get; init; }
+
+    [JsonPropertyName("resultSetIndex")]
+    public int? ResultSetIndex { get; init; }
+}
+
+public record QueryCancelResult
+{
+    [JsonPropertyName("cancelled")]
+    public bool Cancelled { get; init; }
+}

--- a/sidecar/src/Ssmsx.Protocol/Models/QueryModels.cs
+++ b/sidecar/src/Ssmsx.Protocol/Models/QueryModels.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace Ssmsx.Protocol.Models;
+
+public record QueryColumn
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("dataType")]
+    public required string DataType { get; init; }
+
+    [JsonPropertyName("isNullable")]
+    public bool IsNullable { get; init; }
+
+    [JsonPropertyName("maxLength")]
+    public int? MaxLength { get; init; }
+}
+
+public record QueryMessage
+{
+    [JsonPropertyName("text")]
+    public required string Text { get; init; }
+
+    [JsonPropertyName("severity")]
+    public required string Severity { get; init; } // "info" or "error"
+
+    [JsonPropertyName("lineNumber")]
+    public int? LineNumber { get; init; }
+}

--- a/sidecar/src/Ssmsx.Protocol/ProtocolJsonContext.cs
+++ b/sidecar/src/Ssmsx.Protocol/ProtocolJsonContext.cs
@@ -77,6 +77,15 @@ namespace Ssmsx.Protocol;
 [JsonSerializable(typeof(List<List<object?>>))]
 [JsonSerializable(typeof(List<object?>))]
 [JsonSerializable(typeof(List<string>))]
+// Primitive types that can appear in query result rows (needed for polymorphic object? serialization)
+[JsonSerializable(typeof(byte))]
+[JsonSerializable(typeof(short))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(float))]
+[JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(decimal))]
+[JsonSerializable(typeof(string))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/sidecar/src/Ssmsx.Protocol/ProtocolJsonContext.cs
+++ b/sidecar/src/Ssmsx.Protocol/ProtocolJsonContext.cs
@@ -54,6 +54,28 @@ namespace Ssmsx.Protocol;
 [JsonSerializable(typeof(ExplorerFunctionsParams))]
 [JsonSerializable(typeof(ExplorerUsersParams))]
 [JsonSerializable(typeof(ExplorerObjectDefinitionParams))]
+// IntelliSense DTOs
+[JsonSerializable(typeof(IntelliSenseGetMetadataParams))]
+[JsonSerializable(typeof(IntelliSenseMetadata))]
+[JsonSerializable(typeof(IntelliSenseTable))]
+[JsonSerializable(typeof(List<IntelliSenseTable>))]
+[JsonSerializable(typeof(IntelliSenseColumn))]
+[JsonSerializable(typeof(List<IntelliSenseColumn>))]
+[JsonSerializable(typeof(IntelliSenseProcedure))]
+[JsonSerializable(typeof(List<IntelliSenseProcedure>))]
+[JsonSerializable(typeof(IntelliSenseFunction))]
+[JsonSerializable(typeof(List<IntelliSenseFunction>))]
+// Query DTOs
+[JsonSerializable(typeof(QueryColumn))]
+[JsonSerializable(typeof(List<QueryColumn>))]
+[JsonSerializable(typeof(QueryMessage))]
+[JsonSerializable(typeof(List<QueryMessage>))]
+[JsonSerializable(typeof(QueryExecuteParams))]
+[JsonSerializable(typeof(QueryExecuteResult))]
+[JsonSerializable(typeof(QueryCancelParams))]
+[JsonSerializable(typeof(QueryCancelResult))]
+[JsonSerializable(typeof(List<List<object?>>))]
+[JsonSerializable(typeof(List<object?>))]
 [JsonSerializable(typeof(List<string>))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,

--- a/sidecar/src/Ssmsx.Sidecar/Program.cs
+++ b/sidecar/src/Ssmsx.Sidecar/Program.cs
@@ -244,6 +244,24 @@ var streamingHandlers = new Dictionary<string, Func<string, JsonElement?, Stream
         using var cts = new CancellationTokenSource();
         queryCancellationManager.Register(queryId, cts);
 
+        // Send an immediate "started" batch so the frontend knows the queryId
+        // (needed for cancellation before any data arrives)
+        {
+            var startBatch = new QueryExecuteResult
+            {
+                QueryId = queryId,
+                Batch = 0,
+                Done = false
+            };
+            var startElement = JsonSerializer.SerializeToElement(startBatch, ProtocolJsonContext.Default.QueryExecuteResult);
+            var startResponse = new JsonRpcResponse { Id = requestId, Result = startElement };
+            var startJson = JsonSerializer.Serialize(startResponse, ProtocolJsonContext.Default.JsonRpcResponse);
+            lock (writerLock)
+            {
+                w.WriteLine(startJson);
+            }
+        }
+
         try
         {
             await queryExecutor.ExecuteAsync(
@@ -308,10 +326,24 @@ while ((line = Console.ReadLine()) is not null)
 
         requestId = request.Id;
 
-        // Check streaming handlers first — they write their own responses
+        // Check streaming handlers first — they write their own responses.
+        // Fire-and-forget so the main loop can continue processing other requests
+        // (e.g. query.cancel while a query is running).
         if (streamingHandlers.TryGetValue(request.Method, out var streamHandler))
         {
-            await streamHandler(request.Id, request.Params, writer);
+            var capturedId = request.Id;
+            var capturedParams = request.Params;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await streamHandler(capturedId, capturedParams, writer);
+                }
+                catch (Exception ex)
+                {
+                    await Console.Error.WriteLineAsync($"Unhandled error in streaming handler for request '{capturedId}': {ex.Message}");
+                }
+            });
             continue;
         }
 

--- a/sidecar/src/Ssmsx.Sidecar/Program.cs
+++ b/sidecar/src/Ssmsx.Sidecar/Program.cs
@@ -6,6 +6,7 @@ using Ssmsx.Core.Storage;
 using Ssmsx.Core.Connections;
 using Ssmsx.Core.Credentials;
 using Ssmsx.Core.Explorer;
+using Ssmsx.Core.Query;
 
 // Disable stdout buffering for real-time communication
 Console.OutputEncoding = System.Text.Encoding.UTF8;
@@ -15,6 +16,9 @@ var connectionStore = new ConnectionStore();
 var credentialStore = CredentialStoreFactory.Create();
 var connectionManager = new ConnectionManager();
 var schemaDiscovery = new SchemaDiscoveryService(connectionManager);
+var queryCancellationManager = new QueryCancellationManager();
+var queryExecutor = new QueryExecutor(connectionManager, queryCancellationManager);
+var intelliSenseService = new IntelliSenseService(connectionManager);
 
 var handlers = new Dictionary<string, Func<JsonElement?, Task<JsonElement>>>
 {
@@ -206,6 +210,73 @@ var handlers = new Dictionary<string, Func<JsonElement?, Task<JsonElement>>>
         var args = Deserialize<ExplorerObjectDefinitionParams>(p, ProtocolJsonContext.Default.ExplorerObjectDefinitionParams);
         var result = await schemaDiscovery.GetObjectDefinitionAsync(args.ConnectionId, args.Database, args.Schema, args.ObjectName, args.ObjectType);
         return JsonSerializer.SerializeToElement(result, ProtocolJsonContext.Default.ObjectScriptResult);
+    },
+
+    // IntelliSense methods
+    ["intellisense.getMetadata"] = async p =>
+    {
+        var args = Deserialize<IntelliSenseGetMetadataParams>(p, ProtocolJsonContext.Default.IntelliSenseGetMetadataParams);
+        var result = await intelliSenseService.GetMetadataAsync(args.ConnectionId, args.Database);
+        return JsonSerializer.SerializeToElement(result, ProtocolJsonContext.Default.IntelliSenseMetadata);
+    },
+
+    // Query methods
+    ["query.cancel"] = async p =>
+    {
+        var args = Deserialize<QueryCancelParams>(p, ProtocolJsonContext.Default.QueryCancelParams);
+        var cancelled = queryCancellationManager.Cancel(args.QueryId);
+        return JsonSerializer.SerializeToElement(
+            new QueryCancelResult { Cancelled = cancelled },
+            ProtocolJsonContext.Default.QueryCancelResult);
+    }
+};
+
+// Lock object to prevent interleaving of JSON-RPC responses on stdout
+var writerLock = new object();
+
+// Streaming handlers: these write multiple JSON-RPC responses for a single request
+var streamingHandlers = new Dictionary<string, Func<string, JsonElement?, StreamWriter, Task>>
+{
+    ["query.execute"] = async (requestId, p, w) =>
+    {
+        var args = Deserialize<QueryExecuteParams>(p, ProtocolJsonContext.Default.QueryExecuteParams);
+        var queryId = Guid.NewGuid().ToString();
+        using var cts = new CancellationTokenSource();
+        queryCancellationManager.Register(queryId, cts);
+
+        try
+        {
+            await queryExecutor.ExecuteAsync(
+                args.ConnectionId,
+                args.Database,
+                args.Sql,
+                queryId,
+                async batch =>
+                {
+                    var resultElement = JsonSerializer.SerializeToElement(batch, ProtocolJsonContext.Default.QueryExecuteResult);
+                    var response = new JsonRpcResponse { Id = requestId, Result = resultElement };
+                    var json = JsonSerializer.Serialize(response, ProtocolJsonContext.Default.JsonRpcResponse);
+                    lock (writerLock)
+                    {
+                        w.WriteLine(json);
+                    }
+                },
+                cts.Token);
+        }
+        catch (Exception ex)
+        {
+            await Console.Error.WriteLineAsync($"Error executing query '{queryId}': {ex.Message}");
+            var errorResponse = new JsonRpcResponse
+            {
+                Id = requestId,
+                Error = new JsonRpcError { Code = "QUERY_ERROR", Message = ex.Message }
+            };
+            var errorJson = JsonSerializer.Serialize(errorResponse, ProtocolJsonContext.Default.JsonRpcResponse);
+            lock (writerLock)
+            {
+                w.WriteLine(errorJson);
+            }
+        }
     }
 };
 
@@ -236,6 +307,13 @@ while ((line = Console.ReadLine()) is not null)
         }
 
         requestId = request.Id;
+
+        // Check streaming handlers first — they write their own responses
+        if (streamingHandlers.TryGetValue(request.Method, out var streamHandler))
+        {
+            await streamHandler(request.Id, request.Params, writer);
+            continue;
+        }
 
         if (handlers.TryGetValue(request.Method, out var handler))
         {

--- a/sidecar/src/Ssmsx.Sidecar/Program.cs
+++ b/sidecar/src/Ssmsx.Sidecar/Program.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using Ssmsx.Protocol;
 using Ssmsx.Protocol.Messages;
@@ -19,6 +20,32 @@ var schemaDiscovery = new SchemaDiscoveryService(connectionManager);
 var queryCancellationManager = new QueryCancellationManager();
 var queryExecutor = new QueryExecutor(connectionManager, queryCancellationManager);
 var intelliSenseService = new IntelliSenseService(connectionManager);
+
+await using var stdout = Console.OpenStandardOutput();
+using var writer = new StreamWriter(stdout) { AutoFlush = true };
+
+// All stdout writes MUST go through this to prevent interleaving
+var writerLock = new object();
+void WriteResponse(string json)
+{
+    lock (writerLock) { writer.WriteLine(json); }
+}
+
+void SendResult(string requestId, JsonElement result)
+{
+    var response = new JsonRpcResponse { Id = requestId, Result = result };
+    WriteResponse(JsonSerializer.Serialize(response, ProtocolJsonContext.Default.JsonRpcResponse));
+}
+
+void SendError(string requestId, string code, string message)
+{
+    var response = new JsonRpcResponse
+    {
+        Id = requestId,
+        Error = new JsonRpcError { Code = code, Message = message }
+    };
+    WriteResponse(JsonSerializer.Serialize(response, ProtocolJsonContext.Default.JsonRpcResponse));
+}
 
 var handlers = new Dictionary<string, Func<JsonElement?, Task<JsonElement>>>
 {
@@ -44,46 +71,31 @@ var handlers = new Dictionary<string, Func<JsonElement?, Task<JsonElement>>>
     ["connection.save"] = async p =>
     {
         var args = Deserialize<ConnectionSaveParams>(p, ProtocolJsonContext.Default.ConnectionSaveParams);
-        // Store password in keychain if provided
         ConnectionInfo saved;
         if (!string.IsNullOrEmpty(args.Password))
         {
             var credKey = $"ssmsx/{args.Connection.Id}";
             await credentialStore.StoreAsync(credKey, args.Password);
-            // Save connection with credential reference
             saved = args.Connection with { CredentialRef = credKey };
             await connectionStore.SaveAsync(saved);
         }
         else if (args.ClearCredential)
         {
-            // Explicitly clear stored credential
             var existing = await connectionStore.GetAsync(args.Connection.Id);
             if (existing?.CredentialRef != null)
             {
-                try
-                {
-                    await credentialStore.DeleteAsync(existing.CredentialRef);
-                }
-                catch (Exception ex)
-                {
-                    await Console.Error.WriteLineAsync($"Warning: Failed to delete credential '{existing.CredentialRef}' for connection '{args.Connection.Id}': {ex.Message}");
-                }
+                try { await credentialStore.DeleteAsync(existing.CredentialRef); }
+                catch (Exception ex) { await Console.Error.WriteLineAsync($"Warning: Failed to delete credential '{existing.CredentialRef}': {ex.Message}"); }
             }
             saved = args.Connection with { CredentialRef = null };
             await connectionStore.SaveAsync(saved);
         }
         else
         {
-            // No new password and no clear request — preserve existing credential
             var existing = await connectionStore.GetAsync(args.Connection.Id);
-            if (existing?.CredentialRef != null)
-            {
-                saved = args.Connection with { CredentialRef = existing.CredentialRef };
-            }
-            else
-            {
-                saved = args.Connection;
-            }
+            saved = existing?.CredentialRef != null
+                ? args.Connection with { CredentialRef = existing.CredentialRef }
+                : args.Connection;
             await connectionStore.SaveAsync(saved);
         }
         return JsonSerializer.SerializeToElement(saved, ProtocolJsonContext.Default.ConnectionInfo);
@@ -92,15 +104,8 @@ var handlers = new Dictionary<string, Func<JsonElement?, Task<JsonElement>>>
     ["connection.delete"] = async p =>
     {
         var args = Deserialize<ConnectionDeleteParams>(p, ProtocolJsonContext.Default.ConnectionDeleteParams);
-        // Try to delete credential from keychain
-        try
-        {
-            await credentialStore.DeleteAsync($"ssmsx/{args.Id}");
-        }
-        catch (Exception ex)
-        {
-            await Console.Error.WriteLineAsync($"Warning: Failed to delete credential for connection '{args.Id}': {ex.Message}");
-        }
+        try { await credentialStore.DeleteAsync($"ssmsx/{args.Id}"); }
+        catch (Exception ex) { await Console.Error.WriteLineAsync($"Warning: Failed to delete credential for connection '{args.Id}': {ex.Message}"); }
         var deleted = await connectionStore.DeleteAsync(args.Id);
         return JsonSerializer.SerializeToElement(
             new ConnectionDeleteResult { Deleted = deleted },
@@ -141,7 +146,6 @@ var handlers = new Dictionary<string, Func<JsonElement?, Task<JsonElement>>>
         return JsonSerializer.SerializeToElement(true, ProtocolJsonContext.Default.Boolean);
     },
 
-    // Explorer methods
     ["explorer.databases"] = async p =>
     {
         var args = Deserialize<ExplorerDatabasesParams>(p, ProtocolJsonContext.Default.ExplorerDatabasesParams);
@@ -212,7 +216,6 @@ var handlers = new Dictionary<string, Func<JsonElement?, Task<JsonElement>>>
         return JsonSerializer.SerializeToElement(result, ProtocolJsonContext.Default.ObjectScriptResult);
     },
 
-    // IntelliSense methods
     ["intellisense.getMetadata"] = async p =>
     {
         var args = Deserialize<IntelliSenseGetMetadataParams>(p, ProtocolJsonContext.Default.IntelliSenseGetMetadataParams);
@@ -220,166 +223,146 @@ var handlers = new Dictionary<string, Func<JsonElement?, Task<JsonElement>>>
         return JsonSerializer.SerializeToElement(result, ProtocolJsonContext.Default.IntelliSenseMetadata);
     },
 
-    // Query methods
-    ["query.cancel"] = async p =>
-    {
-        var args = Deserialize<QueryCancelParams>(p, ProtocolJsonContext.Default.QueryCancelParams);
-        var cancelled = queryCancellationManager.Cancel(args.QueryId);
-        return JsonSerializer.SerializeToElement(
-            new QueryCancelResult { Cancelled = cancelled },
-            ProtocolJsonContext.Default.QueryCancelResult);
-    }
+    // Note: query.cancel is handled directly on the stdin reader thread
+    // (not here) so it works even while a query blocks the main loop.
 };
 
-// Lock object to prevent interleaving of JSON-RPC responses on stdout
-var writerLock = new object();
+// --- Request processing ---
+// We use a concurrent queue + semaphore so a background stdin reader can enqueue
+// requests while the main processing loop handles them one at a time.
+// This allows query.cancel to be queued and processed between query batches,
+// since async awaits yield control to process the next queued request.
+var requestQueue = new BlockingCollection<string>();
 
-// Streaming handlers: these write multiple JSON-RPC responses for a single request
-var streamingHandlers = new Dictionary<string, Func<string, JsonElement?, StreamWriter, Task>>
+// Background stdin reader — reads lines and enqueues them.
+// Cancel requests are handled inline on this thread (SqlCommand.Cancel is thread-safe)
+// so they work even while a query is blocking the main processing loop.
+var stdinReader = new Thread(() =>
 {
-    ["query.execute"] = async (requestId, p, w) =>
+    string? inputLine;
+    while ((inputLine = Console.ReadLine()) is not null)
     {
-        var args = Deserialize<QueryExecuteParams>(p, ProtocolJsonContext.Default.QueryExecuteParams);
-        var queryId = Guid.NewGuid().ToString();
-        using var cts = new CancellationTokenSource();
-        queryCancellationManager.Register(queryId, cts);
+        if (string.IsNullOrWhiteSpace(inputLine))
+            continue;
 
-        // Send an immediate "started" batch so the frontend knows the queryId
-        // (needed for cancellation before any data arrives)
-        {
-            var startBatch = new QueryExecuteResult
-            {
-                QueryId = queryId,
-                Batch = 0,
-                Done = false
-            };
-            var startElement = JsonSerializer.SerializeToElement(startBatch, ProtocolJsonContext.Default.QueryExecuteResult);
-            var startResponse = new JsonRpcResponse { Id = requestId, Result = startElement };
-            var startJson = JsonSerializer.Serialize(startResponse, ProtocolJsonContext.Default.JsonRpcResponse);
-            lock (writerLock)
-            {
-                w.WriteLine(startJson);
-            }
-        }
-
+        // Fast-path: handle query.cancel directly on the reader thread
+        // so it works even while the main loop is blocked on a streaming query
         try
         {
-            await queryExecutor.ExecuteAsync(
-                args.ConnectionId,
-                args.Database,
-                args.Sql,
-                queryId,
-                async batch =>
+            var peek = JsonSerializer.Deserialize(inputLine, ProtocolJsonContext.Default.JsonRpcRequest);
+            if (peek is not null && peek.Method == "query.cancel")
+            {
+                try
                 {
-                    var resultElement = JsonSerializer.SerializeToElement(batch, ProtocolJsonContext.Default.QueryExecuteResult);
-                    var response = new JsonRpcResponse { Id = requestId, Result = resultElement };
-                    var json = JsonSerializer.Serialize(response, ProtocolJsonContext.Default.JsonRpcResponse);
-                    lock (writerLock)
-                    {
-                        w.WriteLine(json);
-                    }
-                },
-                cts.Token);
-        }
-        catch (Exception ex)
-        {
-            await Console.Error.WriteLineAsync($"Error executing query '{queryId}': {ex.Message}");
-            var errorResponse = new JsonRpcResponse
-            {
-                Id = requestId,
-                Error = new JsonRpcError { Code = "QUERY_ERROR", Message = ex.Message }
-            };
-            var errorJson = JsonSerializer.Serialize(errorResponse, ProtocolJsonContext.Default.JsonRpcResponse);
-            lock (writerLock)
-            {
-                w.WriteLine(errorJson);
+                    var cancelArgs = Deserialize<QueryCancelParams>(peek.Params, ProtocolJsonContext.Default.QueryCancelParams);
+                    var cancelled = queryCancellationManager.Cancel(cancelArgs.QueryId);
+                    var cancelResult = JsonSerializer.SerializeToElement(
+                        new QueryCancelResult { Cancelled = cancelled },
+                        ProtocolJsonContext.Default.QueryCancelResult);
+                    SendResult(peek.Id, cancelResult);
+                }
+                catch (Exception ex)
+                {
+                    SendError(peek.Id, "CANCEL_ERROR", ex.Message);
+                }
+                continue; // Don't enqueue — already handled
             }
         }
+        catch
+        {
+            // If parsing fails, let the main loop handle the error
+        }
+
+        requestQueue.Add(inputLine);
     }
-};
-
-await using var stdout = Console.OpenStandardOutput();
-using var writer = new StreamWriter(stdout) { AutoFlush = true };
-
-string? line;
-while ((line = Console.ReadLine()) is not null)
+    requestQueue.CompleteAdding();
+})
 {
-    if (string.IsNullOrWhiteSpace(line))
-        continue;
+    IsBackground = true,
+    Name = "StdinReader"
+};
+stdinReader.Start();
 
-    JsonRpcResponse response;
+// Main processing loop — processes requests from the queue
+foreach (var requestLine in requestQueue.GetConsumingEnumerable())
+{
     string requestId = "unknown";
     try
     {
-        var request = JsonSerializer.Deserialize(line, ProtocolJsonContext.Default.JsonRpcRequest);
+        var request = JsonSerializer.Deserialize(requestLine, ProtocolJsonContext.Default.JsonRpcRequest);
         if (request is null)
         {
-            response = new JsonRpcResponse
-            {
-                Id = "unknown",
-                Error = new JsonRpcError { Code = "INVALID_REQUEST", Message = "Deserialized request was null" }
-            };
-            var nullJson = JsonSerializer.Serialize(response, ProtocolJsonContext.Default.JsonRpcResponse);
-            await writer.WriteLineAsync(nullJson);
+            SendError("unknown", "INVALID_REQUEST", "Deserialized request was null");
             continue;
         }
 
         requestId = request.Id;
 
-        // Check streaming handlers first — they write their own responses.
-        // Fire-and-forget so the main loop can continue processing other requests
-        // (e.g. query.cancel while a query is running).
-        if (streamingHandlers.TryGetValue(request.Method, out var streamHandler))
+        // query.execute streams multiple responses, then completes
+        if (request.Method == "query.execute")
         {
-            var capturedId = request.Id;
-            var capturedParams = request.Params;
-            _ = Task.Run(async () =>
-            {
-                try
-                {
-                    await streamHandler(capturedId, capturedParams, writer);
-                }
-                catch (Exception ex)
-                {
-                    await Console.Error.WriteLineAsync($"Unhandled error in streaming handler for request '{capturedId}': {ex.Message}");
-                }
-            });
+            await HandleQueryExecute(request.Id, request.Params);
             continue;
         }
 
         if (handlers.TryGetValue(request.Method, out var handler))
         {
             var result = await handler(request.Params);
-            response = new JsonRpcResponse { Id = request.Id, Result = result };
+            SendResult(request.Id, result);
         }
         else
         {
-            response = new JsonRpcResponse
-            {
-                Id = request.Id,
-                Error = new JsonRpcError { Code = "METHOD_NOT_FOUND", Message = $"Unknown method: {request.Method}" }
-            };
+            SendError(request.Id, "METHOD_NOT_FOUND", $"Unknown method: {request.Method}");
         }
     }
     catch (JsonException ex)
     {
-        response = new JsonRpcResponse
-        {
-            Id = "unknown",
-            Error = new JsonRpcError { Code = "PARSE_ERROR", Message = ex.Message }
-        };
+        SendError("unknown", "PARSE_ERROR", ex.Message);
     }
     catch (Exception ex)
     {
-        response = new JsonRpcResponse
+        SendError(requestId, "INTERNAL_ERROR", ex.Message);
+    }
+}
+
+// --- query.execute handler ---
+async Task HandleQueryExecute(string requestId, JsonElement? p)
+{
+    var args = Deserialize<QueryExecuteParams>(p, ProtocolJsonContext.Default.QueryExecuteParams);
+    var queryId = Guid.NewGuid().ToString();
+    using var cts = new CancellationTokenSource();
+    queryCancellationManager.Register(queryId, cts);
+
+    // Send immediate "started" response so frontend knows the queryId for cancellation
+    {
+        var startBatch = new QueryExecuteResult
         {
-            Id = requestId,
-            Error = new JsonRpcError { Code = "INTERNAL_ERROR", Message = ex.Message }
+            QueryId = queryId,
+            Batch = 0,
+            Done = false
         };
+        SendResult(requestId, JsonSerializer.SerializeToElement(startBatch, ProtocolJsonContext.Default.QueryExecuteResult));
     }
 
-    var json = JsonSerializer.Serialize(response, ProtocolJsonContext.Default.JsonRpcResponse);
-    await writer.WriteLineAsync(json);
+    try
+    {
+        await queryExecutor.ExecuteAsync(
+            args.ConnectionId,
+            args.Database,
+            args.Sql,
+            queryId,
+            batch =>
+            {
+                SendResult(requestId, JsonSerializer.SerializeToElement(batch, ProtocolJsonContext.Default.QueryExecuteResult));
+                return Task.CompletedTask;
+            },
+            cts.Token);
+    }
+    catch (Exception ex)
+    {
+        await Console.Error.WriteLineAsync($"Error executing query '{queryId}': {ex.Message}");
+        SendError(requestId, "QUERY_ERROR", ex.Message);
+    }
 }
 
 // Helper to deserialize params with proper error handling

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod connection;
 pub mod explorer;
 pub mod ping;
+pub mod query;

--- a/src-tauri/src/commands/query.rs
+++ b/src-tauri/src/commands/query.rs
@@ -28,7 +28,9 @@ pub async fn query_execute(
 
     let rid = request_id.clone();
 
-    // Spawn a task to read batches and emit Tauri events
+    // Spawn a task to read batches and emit Tauri events.
+    // Each payload gets the requestId injected so the frontend can match
+    // events to tabs (the sidecar's queryId is different from requestId).
     tauri::async_runtime::spawn(async move {
         while let Some(result) = rx.recv().await {
             match result {
@@ -36,14 +38,19 @@ pub async fn query_execute(
                     let done = value.get("done").and_then(|v| v.as_bool()).unwrap_or(false);
                     let has_error = value.get("error").is_some();
 
+                    // Inject requestId into the payload so frontend can correlate
+                    let mut payload = value.as_object().cloned().unwrap_or_default();
+                    payload.insert("requestId".to_string(), serde_json::Value::String(rid.clone()));
+                    let payload = serde_json::Value::Object(payload);
+
                     if has_error {
                         log::warn!("Query '{}' returned an error payload", rid);
-                        let _ = app_handle.emit("query:error", &value);
+                        let _ = app_handle.emit("query:error", &payload);
                     } else if done {
                         log::debug!("Query '{}' completed", rid);
-                        let _ = app_handle.emit("query:complete", &value);
+                        let _ = app_handle.emit("query:complete", &payload);
                     } else {
-                        let _ = app_handle.emit("query:results", &value);
+                        let _ = app_handle.emit("query:results", &payload);
                     }
 
                     // If done or error, stop listening

--- a/src-tauri/src/commands/query.rs
+++ b/src-tauri/src/commands/query.rs
@@ -5,6 +5,7 @@ use tauri::Emitter;
 pub async fn query_execute(
     sidecar: tauri::State<'_, SidecarManager>,
     app_handle: tauri::AppHandle,
+    request_id: String,
     connection_id: String,
     database: String,
     sql: String,
@@ -15,8 +16,11 @@ pub async fn query_execute(
         "sql": sql
     });
 
+    // Use the caller-provided request_id so the frontend can store it in
+    // state BEFORE invoke returns — otherwise streaming events can arrive
+    // before the frontend knows which tab they belong to.
     let (request_id, mut rx) = sidecar
-        .send_streaming_request("query.execute", Some(params))
+        .send_streaming_request_with_id("query.execute", Some(params), request_id)
         .await?;
 
     log::debug!(

--- a/src-tauri/src/commands/query.rs
+++ b/src-tauri/src/commands/query.rs
@@ -1,0 +1,107 @@
+use crate::sidecar::SidecarManager;
+use tauri::Emitter;
+
+#[tauri::command]
+pub async fn query_execute(
+    sidecar: tauri::State<'_, SidecarManager>,
+    app_handle: tauri::AppHandle,
+    connection_id: String,
+    database: String,
+    sql: String,
+) -> Result<String, String> {
+    let params = serde_json::json!({
+        "connectionId": connection_id,
+        "database": database,
+        "sql": sql
+    });
+
+    let (request_id, mut rx) = sidecar
+        .send_streaming_request("query.execute", Some(params))
+        .await?;
+
+    log::debug!(
+        "Query execution started: request_id='{}', connection_id='{}', database='{}'",
+        request_id,
+        connection_id,
+        database
+    );
+
+    let rid = request_id.clone();
+
+    // Spawn a task to read batches and emit Tauri events
+    tauri::async_runtime::spawn(async move {
+        while let Some(result) = rx.recv().await {
+            match result {
+                Ok(value) => {
+                    let done = value.get("done").and_then(|v| v.as_bool()).unwrap_or(false);
+                    let has_error = value.get("error").is_some();
+
+                    if has_error {
+                        log::warn!("Query '{}' returned an error payload", rid);
+                        let _ = app_handle.emit("query:error", &value);
+                    } else if done {
+                        log::debug!("Query '{}' completed", rid);
+                        let _ = app_handle.emit("query:complete", &value);
+                    } else {
+                        let _ = app_handle.emit("query:results", &value);
+                    }
+
+                    // If done or error, stop listening
+                    if done || has_error {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    log::error!("Query '{}' stream error: {}", rid, e);
+                    let error_payload = serde_json::json!({
+                        "requestId": rid,
+                        "error": e
+                    });
+                    let _ = app_handle.emit("query:error", &error_payload);
+                    break;
+                }
+            }
+        }
+    });
+
+    // Return the request ID immediately so frontend can track/cancel
+    serde_json::to_string(&serde_json::json!({ "requestId": request_id }))
+        .map_err(|e| format!("Failed to serialize query response: {}", e))
+}
+
+#[tauri::command]
+pub async fn intellisense_get_metadata(
+    sidecar: tauri::State<'_, SidecarManager>,
+    connection_id: String,
+    database: String,
+) -> Result<String, String> {
+    log::debug!(
+        "IntelliSense metadata request: connection_id='{}', database='{}'",
+        connection_id,
+        database
+    );
+    let params = serde_json::json!({ "connectionId": connection_id, "database": database });
+    let result = sidecar
+        .send_request("intellisense.getMetadata", Some(params))
+        .await?;
+    serde_json::to_string(&result).map_err(|e| {
+        format!(
+            "Failed to serialize IntelliSense metadata for connection '{}', database '{}': {}",
+            connection_id, database, e
+        )
+    })
+}
+
+#[tauri::command]
+pub async fn query_cancel(
+    sidecar: tauri::State<'_, SidecarManager>,
+    query_id: String,
+) -> Result<String, String> {
+    log::debug!("Cancelling query: query_id='{}'", query_id);
+    let params = serde_json::json!({ "queryId": query_id });
+    let result = sidecar
+        .send_request("query.cancel", Some(params))
+        .await?;
+    serde_json::to_string(&result)
+        .map_err(|e| format!("Failed to serialize cancel response for query '{}': {}", query_id, e))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,8 @@
 mod sidecar;
 mod commands;
 
-use tauri::Manager;
+use tauri::{Manager, Emitter};
+use tauri::menu::{MenuBuilder, SubmenuBuilder, MenuItemBuilder, PredefinedMenuItem};
 
 pub fn run() {
     let _ = env_logger::try_init();
@@ -22,6 +23,9 @@ pub fn run() {
 
             app.manage(sidecar_manager);
 
+            // Build application menu
+            build_menu(app)?;
+
             // Auto-open devtools in debug builds
             #[cfg(debug_assertions)]
             {
@@ -31,6 +35,15 @@ pub fn run() {
             }
 
             Ok(())
+        })
+        .on_menu_event(|app, event| {
+            let id = event.id().0.as_str();
+            if let Some(window) = app.get_webview_window("main") {
+                // Emit menu events to the frontend so React can handle them
+                if let Err(e) = window.emit(&format!("menu:{}", id), ()) {
+                    log::error!("Failed to emit menu event '{}': {}", id, e);
+                }
+            }
         })
         .invoke_handler(tauri::generate_handler![
             commands::ping::ping,
@@ -57,4 +70,65 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+fn build_menu(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    let handle = app.handle();
+
+    // -- File menu --
+    let file_menu = SubmenuBuilder::new(handle, "File")
+        .item(&MenuItemBuilder::with_id("new-connection", "New Connection...")
+            .accelerator("CmdOrCtrl+Shift+N")
+            .build(handle)?)
+        .item(&MenuItemBuilder::with_id("new-query", "New Query")
+            .accelerator("CmdOrCtrl+N")
+            .build(handle)?)
+        .separator()
+        .item(&MenuItemBuilder::with_id("close-tab", "Close Tab")
+            .accelerator("CmdOrCtrl+W")
+            .build(handle)?)
+        .separator()
+        .item(&PredefinedMenuItem::quit(handle, None)?)
+        .build()?;
+
+    // -- Edit menu (standard) --
+    let edit_menu = SubmenuBuilder::new(handle, "Edit")
+        .item(&PredefinedMenuItem::undo(handle, None)?)
+        .item(&PredefinedMenuItem::redo(handle, None)?)
+        .separator()
+        .item(&PredefinedMenuItem::cut(handle, None)?)
+        .item(&PredefinedMenuItem::copy(handle, None)?)
+        .item(&PredefinedMenuItem::paste(handle, None)?)
+        .item(&PredefinedMenuItem::select_all(handle, None)?)
+        .build()?;
+
+    // -- Query menu --
+    let query_menu = SubmenuBuilder::new(handle, "Query")
+        .item(&MenuItemBuilder::with_id("execute-query", "Execute")
+            .accelerator("F5")
+            .build(handle)?)
+        .item(&MenuItemBuilder::with_id("execute-selection", "Execute Selection")
+            .accelerator("CmdOrCtrl+Shift+E")
+            .build(handle)?)
+        .separator()
+        .item(&MenuItemBuilder::with_id("cancel-query", "Cancel Execution")
+            .build(handle)?)
+        .build()?;
+
+    // -- View menu --
+    let view_menu = SubmenuBuilder::new(handle, "View")
+        .item(&MenuItemBuilder::with_id("toggle-explorer", "Object Explorer")
+            .build(handle)?)
+        .build()?;
+
+    let menu = MenuBuilder::new(handle)
+        .item(&file_menu)
+        .item(&edit_menu)
+        .item(&query_menu)
+        .item(&view_menu)
+        .build()?;
+
+    app.set_menu(menu)?;
+
+    Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,6 +51,9 @@ pub fn run() {
             commands::explorer::explorer_functions,
             commands::explorer::explorer_users,
             commands::explorer::explorer_object_definition,
+            commands::query::query_execute,
+            commands::query::query_cancel,
+            commands::query::intellisense_get_metadata,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::sync::{Mutex, oneshot};
+use tokio::sync::{Mutex, oneshot, mpsc};
 use tauri::AppHandle;
 use tauri_plugin_shell::ShellExt;
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
@@ -15,6 +15,7 @@ const REQUEST_TIMEOUT_SECS: u64 = 30;
 pub struct SidecarManager {
     child: Arc<Mutex<Option<CommandChild>>>,
     pending: Arc<Mutex<HashMap<String, oneshot::Sender<Result<Value, String>>>>>,
+    pending_stream: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Result<Value, String>>>>>,
     running: Arc<AtomicBool>,
 }
 
@@ -23,6 +24,7 @@ impl SidecarManager {
         Self {
             child: Arc::new(Mutex::new(None)),
             pending: Arc::new(Mutex::new(HashMap::new())),
+            pending_stream: Arc::new(Mutex::new(HashMap::new())),
             running: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -41,6 +43,7 @@ impl SidecarManager {
         self.running.store(true, Ordering::SeqCst);
 
         let pending = self.pending.clone();
+        let pending_stream = self.pending_stream.clone();
         let running = self.running.clone();
         let child_handle = self.child.clone();
 
@@ -59,18 +62,42 @@ impl SidecarManager {
                         match serde_json::from_str::<Value>(line) {
                             Ok(response) => {
                                 if let Some(id) = response.get("id").and_then(|v| v.as_str()) {
-                                    let mut pending = pending.lock().await;
-                                    if let Some(sender) = pending.remove(id) {
+                                    // First check streaming requests
+                                    let mut stream_pending = pending_stream.lock().await;
+                                    if let Some(sender) = stream_pending.get(id) {
                                         if let Some(error) = response.get("error") {
                                             let msg = error
                                                 .get("message")
                                                 .and_then(|v| v.as_str())
                                                 .unwrap_or("Unknown error");
+                                            log::error!("Streaming request '{}' received error: {}", id, msg);
                                             let _ = sender.send(Err(msg.to_string()));
-                                        } else if let Some(result) = response.get("result") {
-                                            let _ = sender.send(Ok(result.clone()));
+                                            stream_pending.remove(id);
                                         } else {
-                                            let _ = sender.send(Ok(Value::Null));
+                                            let result = response.get("result").cloned().unwrap_or(Value::Null);
+                                            let done = result.get("done").and_then(|v| v.as_bool()).unwrap_or(false);
+                                            let _ = sender.send(Ok(result));
+                                            if done {
+                                                log::debug!("Streaming request '{}' completed (done=true)", id);
+                                                stream_pending.remove(id);
+                                            }
+                                        }
+                                    } else {
+                                        drop(stream_pending);
+                                        // Fall back to oneshot pending requests
+                                        let mut pending = pending.lock().await;
+                                        if let Some(sender) = pending.remove(id) {
+                                            if let Some(error) = response.get("error") {
+                                                let msg = error
+                                                    .get("message")
+                                                    .and_then(|v| v.as_str())
+                                                    .unwrap_or("Unknown error");
+                                                let _ = sender.send(Err(msg.to_string()));
+                                            } else if let Some(result) = response.get("result") {
+                                                let _ = sender.send(Ok(result.clone()));
+                                            } else {
+                                                let _ = sender.send(Ok(Value::Null));
+                                            }
                                         }
                                     }
                                 }
@@ -89,9 +116,15 @@ impl SidecarManager {
                         // Mark as not running and clear child handle
                         running.store(false, Ordering::SeqCst);
                         *child_handle.lock().await = None;
-                        // Drain all pending requests so callers fail fast
+                        // Drain all pending oneshot requests so callers fail fast
                         let mut pending = pending.lock().await;
                         for (_, sender) in pending.drain() {
+                            let _ = sender.send(Err("Sidecar process terminated".to_string()));
+                        }
+                        // Drain all pending streaming requests
+                        let mut stream_pending = pending_stream.lock().await;
+                        for (id, sender) in stream_pending.drain() {
+                            log::warn!("Draining streaming request '{}' due to sidecar termination", id);
                             let _ = sender.send(Err("Sidecar process terminated".to_string()));
                         }
                         break;
@@ -181,5 +214,68 @@ impl SidecarManager {
                 ))
             }
         }
+    }
+
+    /// Send a streaming request to the sidecar. Unlike `send_request`, this returns an
+    /// unbounded receiver that yields multiple response batches until the sidecar sends
+    /// a response with `done: true`. The caller is responsible for consuming the receiver.
+    /// Returns the request ID (for tracking/cancellation) and the receiver.
+    pub async fn send_streaming_request(
+        &self,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<(String, mpsc::UnboundedReceiver<Result<Value, String>>), String> {
+        let id = uuid::Uuid::new_v4().to_string();
+
+        let request = serde_json::json!({
+            "id": id,
+            "method": method,
+            "params": params
+        });
+
+        let request_line = format!("{}\n", serde_json::to_string(&request).map_err(|e| {
+            format!("Failed to serialize streaming request for method '{}': {}", method, e)
+        })?);
+
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        if !self.running.load(Ordering::SeqCst) {
+            return Err(format!(
+                "Sidecar not running — cannot send streaming request for method '{}'",
+                method
+            ));
+        }
+
+        log::debug!("Sending streaming request '{}' for method '{}'", id, method);
+
+        // Insert into pending_stream before write so the reader task can match responses
+        {
+            let mut pending_stream = self.pending_stream.lock().await;
+            pending_stream.insert(id.clone(), tx);
+        }
+
+        // Write to sidecar — clean up pending_stream on failure
+        {
+            let mut child_lock = self.child.lock().await;
+            if let Some(child) = child_lock.as_mut() {
+                if let Err(e) = child.write(request_line.as_bytes()) {
+                    let mut pending_stream = self.pending_stream.lock().await;
+                    pending_stream.remove(&id);
+                    return Err(format!(
+                        "Failed to write to sidecar for streaming method '{}': {}",
+                        method, e
+                    ));
+                }
+            } else {
+                let mut pending_stream = self.pending_stream.lock().await;
+                pending_stream.remove(&id);
+                return Err(format!(
+                    "Sidecar not running — cannot send streaming request for method '{}'",
+                    method
+                ));
+            }
+        }
+
+        Ok((id, rx))
     }
 }

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -216,16 +216,20 @@ impl SidecarManager {
         }
     }
 
-    /// Send a streaming request to the sidecar. Unlike `send_request`, this returns an
-    /// unbounded receiver that yields multiple response batches until the sidecar sends
-    /// a response with `done: true`. The caller is responsible for consuming the receiver.
-    /// Returns the request ID (for tracking/cancellation) and the receiver.
-    pub async fn send_streaming_request(
+    /// Send a streaming request to the sidecar using a caller-provided request ID.
+    /// Unlike `send_request`, this returns an unbounded receiver that yields multiple
+    /// response batches until the sidecar sends a response with `done: true`. The
+    /// caller is responsible for consuming the receiver.
+    ///
+    /// The caller provides the request ID so it can be stored in frontend state
+    /// before this call resolves, closing the race where the first streaming batch
+    /// could otherwise arrive before the frontend knows what to correlate it with.
+    pub async fn send_streaming_request_with_id(
         &self,
         method: &str,
         params: Option<Value>,
+        id: String,
     ) -> Result<(String, mpsc::UnboundedReceiver<Result<Value, String>>), String> {
-        let id = uuid::Uuid::new_v4().to_string();
 
         let request = serde_json::json!({
             "id": id,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useCallback } from "react";
 import { useConnectionStore, ConnectionDialog } from "../features/connection";
-import { useQueryStore } from "../features/query";
+import { useQueryStore, QueryPanel, QueryTabBar } from "../features/query";
 import { ObjectExplorerTree } from "../features/explorer";
+
+let tabCounter = 0;
 
 function App() {
   const {
@@ -15,8 +18,53 @@ function App() {
   );
   const hasConnections = activeConnections.length > 0;
 
-  const { tabs, activeTabId } = useQueryStore();
+  const { tabs, activeTabId, addTab } = useQueryStore();
   const activeTab = tabs.find((t) => t.id === activeTabId);
+
+  const createNewTab = useCallback(() => {
+    // Use the first active connection as default
+    const defaultConn = activeConnections[0];
+    if (!defaultConn) return;
+
+    tabCounter++;
+    addTab({
+      id: crypto.randomUUID(),
+      connectionId: defaultConn.id,
+      database: defaultConn.database ?? "master",
+      title: `Query ${tabCounter}`,
+      connectionColor: defaultConn.color,
+    });
+  }, [activeConnections, addTab]);
+
+  // Listen for new tab events from the tab bar's "+" button
+  useEffect(() => {
+    const handler = () => createNewTab();
+    window.addEventListener("query:new-tab", handler);
+    return () => window.removeEventListener("query:new-tab", handler);
+  }, [createNewTab]);
+
+  // Global keyboard shortcuts
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      // Ctrl+N — New query tab
+      if ((e.ctrlKey || e.metaKey) && e.key === "n") {
+        e.preventDefault();
+        createNewTab();
+      }
+
+      // Ctrl+W — Close current tab
+      if ((e.ctrlKey || e.metaKey) && e.key === "w") {
+        e.preventDefault();
+        const store = useQueryStore.getState();
+        if (store.activeTabId) {
+          store.removeTab(store.activeTabId);
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [createNewTab]);
 
   return (
     <div className="flex h-screen flex-col">
@@ -69,60 +117,33 @@ function App() {
         {/* Content area */}
         <div className="flex flex-1 flex-col overflow-hidden">
           {/* Query tabs bar */}
-          {tabs.length > 0 && (
-            <div className="flex border-b border-bg-tertiary bg-bg-secondary">
-              {tabs.map((tab) => (
-                <div
-                  key={tab.id}
-                  className={`flex items-center gap-1 border-r border-bg-tertiary px-3 py-1.5 text-xs ${
-                    tab.id === activeTabId
-                      ? "bg-bg-primary text-text-primary"
-                      : "text-text-secondary hover:bg-bg-tertiary"
-                  }`}
-                >
-                  <button
-                    className="truncate"
-                    onClick={() => useQueryStore.getState().setActiveTab(tab.id)}
-                  >
-                    {tab.title}
-                  </button>
-                  <button
-                    className="ml-1 text-text-secondary hover:text-text-primary"
-                    onClick={() => useQueryStore.getState().removeTab(tab.id)}
-                  >
-                    x
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
+          {tabs.length > 0 && <QueryTabBar />}
 
           {/* Tab content */}
-          <div className="flex flex-1 items-center justify-center overflow-auto">
-            {activeTab ? (
-              <div className="h-full w-full p-4">
-                <pre className="h-full w-full overflow-auto rounded border border-bg-tertiary bg-bg-primary p-3 text-sm text-text-primary">
-                  {activeTab.initialSql}
-                </pre>
-              </div>
-            ) : !hasConnections ? (
-              <div className="text-center">
-                <p className="text-lg text-text-secondary">
-                  Connect to a SQL Server to get started
+          {activeTab ? (
+            <QueryPanel />
+          ) : (
+            <div className="flex flex-1 items-center justify-center overflow-auto">
+              {!hasConnections ? (
+                <div className="text-center">
+                  <p className="text-lg text-text-secondary">
+                    Connect to a SQL Server to get started
+                  </p>
+                  <button
+                    onClick={openDialog}
+                    className="mt-4 rounded bg-accent px-6 py-2 text-accent-text hover:bg-accent-hover"
+                  >
+                    New Connection
+                  </button>
+                </div>
+              ) : (
+                <p className="text-sm text-text-secondary">
+                  Browse objects in the explorer, or press Ctrl+N for a new
+                  query.
                 </p>
-                <button
-                  onClick={openDialog}
-                  className="mt-4 rounded bg-accent px-6 py-2 text-accent-text hover:bg-accent-hover"
-                >
-                  New Connection
-                </button>
-              </div>
-            ) : (
-              <p className="text-sm text-text-secondary">
-                Browse objects in the explorer or right-click to script.
-              </p>
-            )}
-          </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useCallback } from "react";
+import { listen } from "@tauri-apps/api/event";
 import { useConnectionStore, ConnectionDialog } from "../features/connection";
 import { useQueryStore, QueryPanel, QueryTabBar } from "../features/query";
 import { ObjectExplorerTree } from "../features/explorer";
 
 let tabCounter = 0;
+
+function isMac(): boolean {
+  return navigator.platform.toUpperCase().includes("MAC");
+}
 
 function App() {
   const {
@@ -43,28 +48,92 @@ function App() {
     return () => window.removeEventListener("query:new-tab", handler);
   }, [createNewTab]);
 
-  // Global keyboard shortcuts
+  // Listen for native menu events from Tauri
+  useEffect(() => {
+    const unlisteners: Array<() => void> = [];
+
+    const setup = async () => {
+      // File > New Query
+      unlisteners.push(
+        await listen("menu:new-query", () => {
+          createNewTab();
+        })
+      );
+
+      // File > New Connection
+      unlisteners.push(
+        await listen("menu:new-connection", () => {
+          openDialog();
+        })
+      );
+
+      // File > Close Tab
+      unlisteners.push(
+        await listen("menu:close-tab", () => {
+          const store = useQueryStore.getState();
+          if (store.activeTabId) {
+            store.removeTab(store.activeTabId);
+          }
+        })
+      );
+
+      // Query > Execute
+      unlisteners.push(
+        await listen("menu:execute-query", () => {
+          const store = useQueryStore.getState();
+          if (store.activeTabId) {
+            store.executeQuery(store.activeTabId);
+          }
+        })
+      );
+
+      // Query > Execute Selection
+      unlisteners.push(
+        await listen("menu:execute-selection", () => {
+          window.dispatchEvent(new CustomEvent("query:execute-selection"));
+        })
+      );
+
+      // Query > Cancel
+      unlisteners.push(
+        await listen("menu:cancel-query", () => {
+          const store = useQueryStore.getState();
+          if (store.activeTabId) {
+            store.cancelQuery(store.activeTabId);
+          }
+        })
+      );
+    };
+
+    setup().catch((e) =>
+      console.error("Failed to set up menu event listeners:", e)
+    );
+
+    return () => {
+      for (const unlisten of unlisteners) {
+        unlisten();
+      }
+    };
+  }, [createNewTab, openDialog]);
+
+  // Global keyboard shortcuts (F5 for execute when editor is not focused)
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      // Ctrl+N — New query tab
-      if ((e.ctrlKey || e.metaKey) && e.key === "n") {
-        e.preventDefault();
-        createNewTab();
-      }
-
-      // Ctrl+W — Close current tab
-      if ((e.ctrlKey || e.metaKey) && e.key === "w") {
+      // F5 — Execute query (global fallback when editor doesn't have focus)
+      if (e.key === "F5") {
         e.preventDefault();
         const store = useQueryStore.getState();
         if (store.activeTabId) {
-          store.removeTab(store.activeTabId);
+          store.executeQuery(store.activeTabId);
         }
       }
     };
 
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [createNewTab]);
+  }, []);
+
+  const shortcutKey = isMac() ? "⌘" : "Ctrl";
 
   return (
     <div className="flex h-screen flex-col">
@@ -138,8 +207,8 @@ function App() {
                 </div>
               ) : (
                 <p className="text-sm text-text-secondary">
-                  Browse objects in the explorer, or press Ctrl+N for a new
-                  query.
+                  Browse objects in the explorer, or press {shortcutKey}+N for a
+                  new query.
                 </p>
               )}
             </div>

--- a/src/features/query/api/queryApi.ts
+++ b/src/features/query/api/queryApi.ts
@@ -1,0 +1,90 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import type { QueryBatchPayload, QueryErrorPayload } from "../types";
+
+interface QueryExecuteResponse {
+  requestId: string;
+}
+
+export async function queryExecute(
+  connectionId: string,
+  database: string,
+  sql: string
+): Promise<QueryExecuteResponse> {
+  const result = await invoke<string>("query_execute", {
+    connectionId,
+    database,
+    sql,
+  });
+  return JSON.parse(result);
+}
+
+export async function queryCancel(queryId: string): Promise<void> {
+  await invoke<string>("query_cancel", { queryId });
+}
+
+export async function onQueryResults(
+  handler: (payload: QueryBatchPayload) => void
+): Promise<UnlistenFn> {
+  return listen<QueryBatchPayload>("query:results", (event) => {
+    handler(event.payload);
+  });
+}
+
+export async function onQueryComplete(
+  handler: (payload: QueryBatchPayload) => void
+): Promise<UnlistenFn> {
+  return listen<QueryBatchPayload>("query:complete", (event) => {
+    handler(event.payload);
+  });
+}
+
+export interface IntelliSenseMetadata {
+  tables: IntelliSenseTable[];
+  columns: IntelliSenseColumn[];
+  procedures: IntelliSenseProcedure[];
+  functions: IntelliSenseFunction[];
+}
+
+export interface IntelliSenseTable {
+  schema: string;
+  name: string;
+  type: string;
+}
+
+export interface IntelliSenseColumn {
+  schema: string;
+  tableName: string;
+  name: string;
+  dataType: string;
+}
+
+export interface IntelliSenseProcedure {
+  schema: string;
+  name: string;
+}
+
+export interface IntelliSenseFunction {
+  schema: string;
+  name: string;
+  type: string;
+}
+
+export async function intellisenseGetMetadata(
+  connectionId: string,
+  database: string
+): Promise<IntelliSenseMetadata> {
+  const result = await invoke<string>("intellisense_get_metadata", {
+    connectionId,
+    database,
+  });
+  return JSON.parse(result);
+}
+
+export async function onQueryError(
+  handler: (payload: QueryErrorPayload) => void
+): Promise<UnlistenFn> {
+  return listen<QueryErrorPayload>("query:error", (event) => {
+    handler(event.payload);
+  });
+}

--- a/src/features/query/api/queryApi.ts
+++ b/src/features/query/api/queryApi.ts
@@ -7,11 +7,13 @@ interface QueryExecuteResponse {
 }
 
 export async function queryExecute(
+  requestId: string,
   connectionId: string,
   database: string,
   sql: string
 ): Promise<QueryExecuteResponse> {
   const result = await invoke<string>("query_execute", {
+    requestId,
     connectionId,
     database,
     sql,

--- a/src/features/query/api/queryEventListeners.ts
+++ b/src/features/query/api/queryEventListeners.ts
@@ -1,0 +1,41 @@
+import { useQueryStore } from "../store/queryStore";
+import { onQueryResults, onQueryComplete, onQueryError } from "./queryApi";
+
+let initialized = false;
+
+/**
+ * Register Tauri event listeners for query streaming.
+ *
+ * This is called ONCE at app startup (from main.tsx), not from a React effect.
+ * Tying listener lifecycle to component mount/unmount caused problems in
+ * React strict mode: the async setup/cleanup race would leave Tauri's
+ * internal listener registry in an inconsistent state, breaking the
+ * listener chain (symptom: "listeners[eventId].handlerId" undefined error).
+ *
+ * Listeners are wired directly to the zustand store (which is already a
+ * global singleton), so there's no reason to scope them to a component.
+ */
+export async function initQueryEventListeners(): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+
+  try {
+    await onQueryResults((payload) => {
+      useQueryStore.getState().handleResultsBatch(payload);
+    });
+
+    await onQueryComplete((payload) => {
+      useQueryStore.getState().handleQueryComplete(payload);
+    });
+
+    await onQueryError((payload) => {
+      useQueryStore
+        .getState()
+        .handleQueryError(payload.queryId, payload.requestId, payload.error);
+    });
+  } catch (e) {
+    console.error("Failed to initialize query event listeners:", e);
+    // Reset flag so we can try again if needed
+    initialized = false;
+  }
+}

--- a/src/features/query/components/QueryEditor.tsx
+++ b/src/features/query/components/QueryEditor.tsx
@@ -56,6 +56,17 @@ export function QueryEditor({
     }
   }, [intellisenseMetadata]);
 
+  // Dispose the Monaco completion provider on unmount.
+  // registerCompletionItemProvider registers globally on the Monaco module, so
+  // if we don't dispose, switching tabs leaks providers and duplicates suggestions.
+  useEffect(() => {
+    return () => {
+      disposableRef.current?.dispose();
+      disposableRef.current = null;
+      completionProviderRef.current = null;
+    };
+  }, []);
+
   // Listen for toolbar "Execute Selection" button
   useEffect(() => {
     const handler = () => {

--- a/src/features/query/components/QueryEditor.tsx
+++ b/src/features/query/components/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useEffect } from "react";
+import { useRef, useCallback, useEffect, useState } from "react";
 import Editor, { type OnMount, type Monaco } from "@monaco-editor/react";
 import type { editor as monacoEditor, IDisposable } from "monaco-editor";
 import { SqlCompletionProvider } from "./intellisense/SqlCompletionProvider";
@@ -12,6 +12,24 @@ interface QueryEditorProps {
   intellisenseMetadata?: IntelliSenseMetadata | null;
 }
 
+/** Detect system color scheme preference */
+function useColorScheme(): "vs" | "vs-dark" {
+  const [scheme, setScheme] = useState<"vs" | "vs-dark">(() =>
+    window.matchMedia("(prefers-color-scheme: dark)").matches ? "vs-dark" : "vs"
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e: MediaQueryListEvent) => {
+      setScheme(e.matches ? "vs-dark" : "vs");
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  return scheme;
+}
+
 export function QueryEditor({
   value,
   onChange,
@@ -23,6 +41,13 @@ export function QueryEditor({
   const completionProviderRef = useRef<SqlCompletionProvider | null>(null);
   const disposableRef = useRef<IDisposable | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
+  const theme = useColorScheme();
+
+  // Keep latest callbacks in refs so Monaco actions always call the current ones
+  const onExecuteRef = useRef(onExecute);
+  onExecuteRef.current = onExecute;
+  const onExecuteSelectionRef = useRef(onExecuteSelection);
+  onExecuteSelectionRef.current = onExecuteSelection;
 
   // Update completion provider when metadata changes
   useEffect(() => {
@@ -30,6 +55,30 @@ export function QueryEditor({
       completionProviderRef.current.setMetadata(intellisenseMetadata ?? null);
     }
   }, [intellisenseMetadata]);
+
+  // Listen for toolbar "Execute Selection" button
+  useEffect(() => {
+    const handler = () => {
+      const editor = editorRef.current;
+      if (!editor) return;
+      const model = editor.getModel();
+      if (!model) return;
+
+      const selection = editor.getSelection();
+      let selectedText = "";
+      if (selection && !selection.isEmpty()) {
+        selectedText = model.getValueInRange(selection);
+      } else {
+        selectedText = getCurrentStatement(model, editor.getPosition());
+      }
+
+      if (selectedText.trim()) {
+        onExecuteSelectionRef.current(selectedText);
+      }
+    };
+    window.addEventListener("query:execute-selection", handler);
+    return () => window.removeEventListener("query:execute-selection", handler);
+  }, []);
 
   const handleMount: OnMount = useCallback(
     (editor, monaco) => {
@@ -49,23 +98,18 @@ export function QueryEditor({
       editor.addAction({
         id: "query-execute",
         label: "Execute Query",
-        keybindings: [
-          // Monaco KeyCode for F5 = 296 (KeyCode.F5)
-          296,
-        ],
+        keybindings: [monaco.KeyCode.F5],
         run: () => {
-          onExecute();
+          onExecuteRef.current();
         },
       });
 
-      // Ctrl+Shift+E — Execute selection or current statement
+      // Cmd/Ctrl+Shift+E — Execute selection or current statement
       editor.addAction({
         id: "query-execute-selection",
         label: "Execute Selection",
         keybindings: [
-          // Ctrl+Shift+E
-          // Monaco: CtrlCmd (2048) | Shift (1024) | KeyE (35)
-          2048 | 1024 | 35,
+          monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyE,
         ],
         run: (ed) => {
           const selection = ed.getSelection();
@@ -81,14 +125,16 @@ export function QueryEditor({
           }
 
           if (selectedText.trim()) {
-            onExecuteSelection(selectedText);
+            onExecuteSelectionRef.current(selectedText);
           }
         },
       });
 
       editor.focus();
     },
-    [onExecute, onExecuteSelection]
+    // Only depends on initial intellisenseMetadata — refs handle callback updates
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [intellisenseMetadata]
   );
 
   const handleChange = useCallback(
@@ -101,7 +147,7 @@ export function QueryEditor({
   return (
     <Editor
       defaultLanguage="sql"
-      theme="vs-dark"
+      theme={theme}
       value={value}
       onChange={handleChange}
       onMount={handleMount}

--- a/src/features/query/components/QueryEditor.tsx
+++ b/src/features/query/components/QueryEditor.tsx
@@ -1,0 +1,166 @@
+import { useRef, useCallback, useEffect } from "react";
+import Editor, { type OnMount, type Monaco } from "@monaco-editor/react";
+import type { editor as monacoEditor, IDisposable } from "monaco-editor";
+import { SqlCompletionProvider } from "./intellisense/SqlCompletionProvider";
+import type { IntelliSenseMetadata } from "../api/queryApi";
+
+interface QueryEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  onExecute: () => void;
+  onExecuteSelection: (sql: string) => void;
+  intellisenseMetadata?: IntelliSenseMetadata | null;
+}
+
+export function QueryEditor({
+  value,
+  onChange,
+  onExecute,
+  onExecuteSelection,
+  intellisenseMetadata,
+}: QueryEditorProps) {
+  const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null);
+  const completionProviderRef = useRef<SqlCompletionProvider | null>(null);
+  const disposableRef = useRef<IDisposable | null>(null);
+  const monacoRef = useRef<Monaco | null>(null);
+
+  // Update completion provider when metadata changes
+  useEffect(() => {
+    if (completionProviderRef.current) {
+      completionProviderRef.current.setMetadata(intellisenseMetadata ?? null);
+    }
+  }, [intellisenseMetadata]);
+
+  const handleMount: OnMount = useCallback(
+    (editor, monaco) => {
+      editorRef.current = editor;
+      monacoRef.current = monaco;
+
+      // Register SQL completion provider (once per editor)
+      const provider = new SqlCompletionProvider();
+      provider.setMetadata(intellisenseMetadata ?? null);
+      completionProviderRef.current = provider;
+      disposableRef.current = monaco.languages.registerCompletionItemProvider(
+        "sql",
+        provider
+      );
+
+      // F5 — Execute entire query
+      editor.addAction({
+        id: "query-execute",
+        label: "Execute Query",
+        keybindings: [
+          // Monaco KeyCode for F5 = 296 (KeyCode.F5)
+          296,
+        ],
+        run: () => {
+          onExecute();
+        },
+      });
+
+      // Ctrl+Shift+E — Execute selection or current statement
+      editor.addAction({
+        id: "query-execute-selection",
+        label: "Execute Selection",
+        keybindings: [
+          // Ctrl+Shift+E
+          // Monaco: CtrlCmd (2048) | Shift (1024) | KeyE (35)
+          2048 | 1024 | 35,
+        ],
+        run: (ed) => {
+          const selection = ed.getSelection();
+          const model = ed.getModel();
+          if (!model) return;
+
+          let selectedText = "";
+          if (selection && !selection.isEmpty()) {
+            selectedText = model.getValueInRange(selection);
+          } else {
+            // No selection — find current statement between GO delimiters
+            selectedText = getCurrentStatement(model, ed.getPosition());
+          }
+
+          if (selectedText.trim()) {
+            onExecuteSelection(selectedText);
+          }
+        },
+      });
+
+      editor.focus();
+    },
+    [onExecute, onExecuteSelection]
+  );
+
+  const handleChange = useCallback(
+    (val: string | undefined) => {
+      onChange(val ?? "");
+    },
+    [onChange]
+  );
+
+  return (
+    <Editor
+      defaultLanguage="sql"
+      theme="vs-dark"
+      value={value}
+      onChange={handleChange}
+      onMount={handleMount}
+      options={{
+        minimap: { enabled: false },
+        fontSize: 14,
+        lineNumbers: "on",
+        wordWrap: "on",
+        automaticLayout: true,
+        scrollBeyondLastLine: false,
+        renderWhitespace: "none",
+        tabSize: 4,
+        insertSpaces: true,
+        suggestOnTriggerCharacters: true,
+        quickSuggestions: true,
+      }}
+    />
+  );
+}
+
+/**
+ * Find the current SQL statement at the cursor position,
+ * delimited by GO on its own line or start/end of file.
+ */
+function getCurrentStatement(
+  model: monacoEditor.ITextModel,
+  position: { lineNumber: number; column: number } | null
+): string {
+  if (!position) return model.getValue();
+
+  const lineCount = model.getLineCount();
+  const goPattern = /^\s*GO\s*$/i;
+
+  // Search backwards from cursor to find the start of the current statement
+  let startLine = 1;
+  for (let i = position.lineNumber - 1; i >= 1; i--) {
+    if (goPattern.test(model.getLineContent(i))) {
+      startLine = i + 1;
+      break;
+    }
+  }
+
+  // Search forwards from cursor to find the end of the current statement
+  let endLine = lineCount;
+  for (let i = position.lineNumber; i <= lineCount; i++) {
+    if (goPattern.test(model.getLineContent(i))) {
+      endLine = i - 1;
+      break;
+    }
+  }
+
+  if (startLine > endLine) return "";
+
+  const range = {
+    startLineNumber: startLine,
+    startColumn: 1,
+    endLineNumber: endLine,
+    endColumn: model.getLineMaxColumn(endLine),
+  };
+
+  return model.getValueInRange(range);
+}

--- a/src/features/query/components/QueryPanel.tsx
+++ b/src/features/query/components/QueryPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useState } from "react";
 import { useQueryStore } from "../store/queryStore";
 import { QueryEditor } from "./QueryEditor";
+import { QueryToolbar } from "./QueryToolbar";
 import { QueryStatusBar } from "./QueryStatusBar";
 import { QueryResultsTable } from "./QueryResultsTable";
 import {
@@ -11,7 +12,7 @@ import {
 } from "../api/queryApi";
 
 export function QueryPanel() {
-  const { activeTabId, tabs, tabSql, updateSql, executeQuery, results, loadIntelliSense } =
+  const { activeTabId, tabs, tabSql, updateSql, executeQuery, cancelQuery, results, loadIntelliSense } =
     useQueryStore();
 
   const activeTab = tabs.find((t) => t.id === activeTabId);
@@ -101,6 +102,18 @@ export function QueryPanel() {
     [activeTabId, executeQuery]
   );
 
+  // For toolbar "Execute Selection" button (no sql param — triggers via the editor ref)
+  const handleExecuteSelectionFromToolbar = useCallback(() => {
+    // Dispatch a custom event the editor can pick up to execute the current selection
+    window.dispatchEvent(new CustomEvent("query:execute-selection"));
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    if (activeTabId) {
+      cancelQuery(activeTabId);
+    }
+  }, [activeTabId, cancelQuery]);
+
   if (!activeTab || !activeTabId) {
     return null;
   }
@@ -111,6 +124,14 @@ export function QueryPanel() {
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
+      {/* Toolbar */}
+      <QueryToolbar
+        tabId={activeTabId}
+        onExecute={handleExecute}
+        onExecuteSelection={handleExecuteSelectionFromToolbar}
+        onCancel={handleCancel}
+      />
+
       {/* Editor area */}
       <div className={`flex-1 ${hasResults ? "min-h-[120px]" : ""}`}>
         <QueryEditor

--- a/src/features/query/components/QueryPanel.tsx
+++ b/src/features/query/components/QueryPanel.tsx
@@ -61,8 +61,7 @@ export function QueryPanel() {
       unlisteners.push(unlisten2);
 
       const unlisten3 = await onQueryError((payload) => {
-        const id = payload.queryId ?? "";
-        store.handleQueryError(id, payload.error);
+        store.handleQueryError(payload.queryId, payload.requestId, payload.error);
       });
       unlisteners.push(unlisten3);
     };

--- a/src/features/query/components/QueryPanel.tsx
+++ b/src/features/query/components/QueryPanel.tsx
@@ -4,12 +4,7 @@ import { QueryEditor } from "./QueryEditor";
 import { QueryToolbar } from "./QueryToolbar";
 import { QueryStatusBar } from "./QueryStatusBar";
 import { QueryResultsTable } from "./QueryResultsTable";
-import {
-  onQueryResults,
-  onQueryComplete,
-  onQueryError,
-  type IntelliSenseMetadata,
-} from "../api/queryApi";
+import type { IntelliSenseMetadata } from "../api/queryApi";
 
 export function QueryPanel() {
   const { activeTabId, tabs, tabSql, updateSql, executeQuery, cancelQuery, results, loadIntelliSense } =
@@ -43,44 +38,9 @@ export function QueryPanel() {
     };
   }, [activeTab?.connectionId, activeTab?.database, loadIntelliSense]);
 
-  // Subscribe to Tauri events for streaming results.
-  // Uses a cancelled flag to prevent double-registration in React strict mode
-  // (where the async setup can complete after the cleanup has already run).
-  useEffect(() => {
-    let cancelled = false;
-    const unlisteners: Array<() => void> = [];
-
-    const setup = async () => {
-      const unlisten1 = await onQueryResults((payload) => {
-        if (!cancelled) useQueryStore.getState().handleResultsBatch(payload);
-      });
-      if (cancelled) { unlisten1(); return; }
-      unlisteners.push(unlisten1);
-
-      const unlisten2 = await onQueryComplete((payload) => {
-        if (!cancelled) useQueryStore.getState().handleQueryComplete(payload);
-      });
-      if (cancelled) { unlisten2(); return; }
-      unlisteners.push(unlisten2);
-
-      const unlisten3 = await onQueryError((payload) => {
-        if (!cancelled) useQueryStore.getState().handleQueryError(payload.queryId, payload.requestId, payload.error);
-      });
-      if (cancelled) { unlisten3(); return; }
-      unlisteners.push(unlisten3);
-    };
-
-    setup().catch((e) =>
-      console.error("Failed to set up query event listeners:", e)
-    );
-
-    return () => {
-      cancelled = true;
-      for (const unlisten of unlisteners) {
-        unlisten();
-      }
-    };
-  }, []);
+  // Note: Tauri event listeners are registered once at app startup in main.tsx
+  // (via initQueryEventListeners) — not here — to avoid React strict mode
+  // breaking Tauri's internal listener registry.
 
   const handleChange = useCallback(
     (value: string) => {

--- a/src/features/query/components/QueryPanel.tsx
+++ b/src/features/query/components/QueryPanel.tsx
@@ -43,26 +43,30 @@ export function QueryPanel() {
     };
   }, [activeTab?.connectionId, activeTab?.database, loadIntelliSense]);
 
-  // Subscribe to Tauri events for streaming results
+  // Subscribe to Tauri events for streaming results.
+  // Uses a cancelled flag to prevent double-registration in React strict mode
+  // (where the async setup can complete after the cleanup has already run).
   useEffect(() => {
+    let cancelled = false;
     const unlisteners: Array<() => void> = [];
 
     const setup = async () => {
-      const store = useQueryStore.getState();
-
       const unlisten1 = await onQueryResults((payload) => {
-        store.handleResultsBatch(payload);
+        if (!cancelled) useQueryStore.getState().handleResultsBatch(payload);
       });
+      if (cancelled) { unlisten1(); return; }
       unlisteners.push(unlisten1);
 
       const unlisten2 = await onQueryComplete((payload) => {
-        store.handleQueryComplete(payload);
+        if (!cancelled) useQueryStore.getState().handleQueryComplete(payload);
       });
+      if (cancelled) { unlisten2(); return; }
       unlisteners.push(unlisten2);
 
       const unlisten3 = await onQueryError((payload) => {
-        store.handleQueryError(payload.queryId, payload.requestId, payload.error);
+        if (!cancelled) useQueryStore.getState().handleQueryError(payload.queryId, payload.requestId, payload.error);
       });
+      if (cancelled) { unlisten3(); return; }
       unlisteners.push(unlisten3);
     };
 
@@ -71,6 +75,7 @@ export function QueryPanel() {
     );
 
     return () => {
+      cancelled = true;
       for (const unlisten of unlisteners) {
         unlisten();
       }

--- a/src/features/query/components/QueryPanel.tsx
+++ b/src/features/query/components/QueryPanel.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useCallback, useState } from "react";
+import { useQueryStore } from "../store/queryStore";
+import { QueryEditor } from "./QueryEditor";
+import { QueryStatusBar } from "./QueryStatusBar";
+import { QueryResultsTable } from "./QueryResultsTable";
+import {
+  onQueryResults,
+  onQueryComplete,
+  onQueryError,
+  type IntelliSenseMetadata,
+} from "../api/queryApi";
+
+export function QueryPanel() {
+  const { activeTabId, tabs, tabSql, updateSql, executeQuery, results, loadIntelliSense } =
+    useQueryStore();
+
+  const activeTab = tabs.find((t) => t.id === activeTabId);
+  const activeSql = activeTabId ? tabSql[activeTabId] ?? "" : "";
+  const activeResult = activeTabId ? results[activeTabId] : undefined;
+
+  // IntelliSense metadata for the active tab's connection/database
+  const [intellisenseMetadata, setIntellisenseMetadata] =
+    useState<IntelliSenseMetadata | null>(null);
+
+  useEffect(() => {
+    if (!activeTab) {
+      setIntellisenseMetadata(null);
+      return;
+    }
+
+    let cancelled = false;
+    loadIntelliSense(activeTab.connectionId, activeTab.database).then(
+      (metadata) => {
+        if (!cancelled) {
+          setIntellisenseMetadata(metadata ?? null);
+        }
+      }
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab?.connectionId, activeTab?.database, loadIntelliSense]);
+
+  // Subscribe to Tauri events for streaming results
+  useEffect(() => {
+    const unlisteners: Array<() => void> = [];
+
+    const setup = async () => {
+      const store = useQueryStore.getState();
+
+      const unlisten1 = await onQueryResults((payload) => {
+        store.handleResultsBatch(payload);
+      });
+      unlisteners.push(unlisten1);
+
+      const unlisten2 = await onQueryComplete((payload) => {
+        store.handleQueryComplete(payload);
+      });
+      unlisteners.push(unlisten2);
+
+      const unlisten3 = await onQueryError((payload) => {
+        const id = payload.queryId ?? "";
+        store.handleQueryError(id, payload.error);
+      });
+      unlisteners.push(unlisten3);
+    };
+
+    setup().catch((e) =>
+      console.error("Failed to set up query event listeners:", e)
+    );
+
+    return () => {
+      for (const unlisten of unlisteners) {
+        unlisten();
+      }
+    };
+  }, []);
+
+  const handleChange = useCallback(
+    (value: string) => {
+      if (activeTabId) {
+        updateSql(activeTabId, value);
+      }
+    },
+    [activeTabId, updateSql]
+  );
+
+  const handleExecute = useCallback(() => {
+    if (activeTabId) {
+      executeQuery(activeTabId);
+    }
+  }, [activeTabId, executeQuery]);
+
+  const handleExecuteSelection = useCallback(
+    (sql: string) => {
+      if (activeTabId) {
+        executeQuery(activeTabId, sql);
+      }
+    },
+    [activeTabId, executeQuery]
+  );
+
+  if (!activeTab || !activeTabId) {
+    return null;
+  }
+
+  const hasResults =
+    activeResult &&
+    (activeResult.columns.length > 0 || activeResult.messages.length > 0);
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      {/* Editor area */}
+      <div className={`flex-1 ${hasResults ? "min-h-[120px]" : ""}`}>
+        <QueryEditor
+          value={activeSql}
+          onChange={handleChange}
+          onExecute={handleExecute}
+          onExecuteSelection={handleExecuteSelection}
+          intellisenseMetadata={intellisenseMetadata}
+        />
+      </div>
+
+      {/* Results area */}
+      {hasResults && (
+        <div className="flex max-h-[50%] flex-col overflow-hidden border-t border-bg-tertiary">
+          <QueryResultsTable result={activeResult} />
+        </div>
+      )}
+
+      {/* Status bar */}
+      <QueryStatusBar tabId={activeTabId} />
+    </div>
+  );
+}

--- a/src/features/query/components/QueryResultsTable.tsx
+++ b/src/features/query/components/QueryResultsTable.tsx
@@ -1,0 +1,107 @@
+import type { QueryResult } from "../types";
+
+interface QueryResultsTableProps {
+  result: QueryResult;
+}
+
+/** Maximum rows to render in the basic table (M4 will replace with virtualization) */
+const MAX_DISPLAY_ROWS = 1000;
+
+export function QueryResultsTable({ result }: QueryResultsTableProps) {
+  const hasData = result.columns.length > 0 && result.rows.length > 0;
+  const hasMessages = result.messages.length > 0;
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      {/* Results tab header */}
+      <div className="flex border-b border-bg-tertiary bg-bg-secondary text-xs">
+        {hasData && (
+          <span className="border-b-2 border-accent px-3 py-1 text-text-primary">
+            Results ({result.totalRows.toLocaleString()})
+          </span>
+        )}
+        {hasMessages && (
+          <span
+            className={`px-3 py-1 text-text-secondary ${!hasData ? "border-b-2 border-accent text-text-primary" : ""}`}
+          >
+            Messages ({result.messages.length})
+          </span>
+        )}
+      </div>
+
+      {/* Data grid */}
+      {hasData && (
+        <div className="flex-1 overflow-auto">
+          <table className="w-full border-collapse text-xs">
+            <thead className="sticky top-0 bg-bg-secondary">
+              <tr>
+                {result.columns.map((col, i) => (
+                  <th
+                    key={`${col.name}-${i}`}
+                    className="whitespace-nowrap border-b border-r border-bg-tertiary px-2 py-1 text-left font-medium text-text-secondary"
+                    title={`${col.dataType}${col.isNullable ? " (nullable)" : ""}`}
+                  >
+                    {col.name}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {result.rows.slice(0, MAX_DISPLAY_ROWS).map((row, rowIndex) => (
+                <tr
+                  key={rowIndex}
+                  className="hover:bg-bg-secondary"
+                >
+                  {row.map((cell, colIndex) => (
+                    <td
+                      key={colIndex}
+                      className="whitespace-nowrap border-b border-r border-bg-tertiary px-2 py-0.5 text-text-primary"
+                    >
+                      {formatCell(cell)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {result.rows.length > MAX_DISPLAY_ROWS && (
+            <div className="bg-bg-secondary px-3 py-1.5 text-center text-xs text-text-secondary">
+              Showing {MAX_DISPLAY_ROWS.toLocaleString()} of{" "}
+              {result.totalRows.toLocaleString()} rows. Full virtualized grid
+              coming in M4.
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Messages */}
+      {hasMessages && !hasData && (
+        <div className="flex-1 overflow-auto p-2">
+          {result.messages.map((msg, i) => (
+            <div
+              key={i}
+              className={`py-0.5 font-mono text-xs ${
+                msg.severity === "error"
+                  ? "text-error"
+                  : "text-text-secondary"
+              }`}
+            >
+              {msg.lineNumber != null && (
+                <span className="text-text-secondary">
+                  Line {msg.lineNumber}:{" "}
+                </span>
+              )}
+              {msg.text}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return "NULL";
+  if (typeof value === "boolean") return value ? "1" : "0";
+  return String(value);
+}

--- a/src/features/query/components/QueryResultsTable.tsx
+++ b/src/features/query/components/QueryResultsTable.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import type { QueryResult } from "../types";
 
 interface QueryResultsTableProps {
@@ -7,30 +8,62 @@ interface QueryResultsTableProps {
 /** Maximum rows to render in the basic table (M4 will replace with virtualization) */
 const MAX_DISPLAY_ROWS = 1000;
 
+type ActiveTab = "results" | "messages";
+
 export function QueryResultsTable({ result }: QueryResultsTableProps) {
   const hasData = result.columns.length > 0 && result.rows.length > 0;
   const hasMessages = result.messages.length > 0;
 
+  // Default tab: Results if we have data, otherwise Messages.
+  // Users can click to switch between them when both exist.
+  const [activeTab, setActiveTab] = useState<ActiveTab>(
+    hasData ? "results" : "messages"
+  );
+
+  // If the situation changes (e.g. a new execution that only produced messages),
+  // snap the active tab back to whichever has content.
+  useEffect(() => {
+    if (activeTab === "results" && !hasData && hasMessages) {
+      setActiveTab("messages");
+    } else if (activeTab === "messages" && !hasMessages && hasData) {
+      setActiveTab("results");
+    }
+  }, [hasData, hasMessages, activeTab]);
+
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
-      {/* Results tab header */}
+      {/* Tab header — both tabs are clickable when present */}
       <div className="flex border-b border-bg-tertiary bg-bg-secondary text-xs">
         {hasData && (
-          <span className="border-b-2 border-accent px-3 py-1 text-text-primary">
+          <button
+            type="button"
+            onClick={() => setActiveTab("results")}
+            className={`px-3 py-1 ${
+              activeTab === "results"
+                ? "border-b-2 border-accent text-text-primary"
+                : "text-text-secondary hover:text-text-primary"
+            }`}
+          >
             Results ({result.totalRows.toLocaleString()})
-          </span>
+          </button>
         )}
         {hasMessages && (
-          <span
-            className={`px-3 py-1 text-text-secondary ${!hasData ? "border-b-2 border-accent text-text-primary" : ""}`}
+          <button
+            type="button"
+            onClick={() => setActiveTab("messages")}
+            className={`px-3 py-1 ${
+              activeTab === "messages"
+                ? "border-b-2 border-accent text-text-primary"
+                : "text-text-secondary hover:text-text-primary"
+            }`}
           >
             Messages ({result.messages.length})
-          </span>
+          </button>
         )}
       </div>
 
       {/* Data grid */}
-      {hasData && (
+      {activeTab === "results" && hasData && (
         <div className="flex-1 overflow-auto">
           <table className="w-full border-collapse text-xs">
             <thead className="sticky top-0 bg-bg-secondary">
@@ -75,7 +108,7 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
       )}
 
       {/* Messages */}
-      {hasMessages && !hasData && (
+      {activeTab === "messages" && hasMessages && (
         <div className="flex-1 overflow-auto p-2">
           {result.messages.map((msg, i) => (
             <div

--- a/src/features/query/components/QueryStatusBar.tsx
+++ b/src/features/query/components/QueryStatusBar.tsx
@@ -1,0 +1,122 @@
+import { useState, useEffect, useRef } from "react";
+import { useQueryStore } from "../store/queryStore";
+import { useConnectionStore } from "../../connection";
+import type { QueryExecutionState } from "../types";
+
+interface QueryStatusBarProps {
+  tabId: string;
+}
+
+const STATE_LABELS: Record<QueryExecutionState, string> = {
+  idle: "Ready",
+  executing: "Executing...",
+  completed: "Completed",
+  failed: "Failed",
+  cancelled: "Cancelled",
+};
+
+const STATE_COLORS: Record<QueryExecutionState, string> = {
+  idle: "text-text-secondary",
+  executing: "text-accent",
+  completed: "text-success",
+  failed: "text-error",
+  cancelled: "text-warning",
+};
+
+export function QueryStatusBar({ tabId }: QueryStatusBarProps) {
+  const tab = useQueryStore((s) => s.tabs.find((t) => t.id === tabId));
+  const executionInfo = useQueryStore((s) => s.executionInfo[tabId]);
+  const result = useQueryStore((s) => s.results[tabId]);
+  const connections = useConnectionStore((s) => s.connections);
+
+  const state = executionInfo?.state ?? "idle";
+  const connection = tab
+    ? connections.find((c) => c.id === tab.connectionId)
+    : null;
+
+  // Live timer
+  const [elapsed, setElapsed] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (state === "executing" && executionInfo?.startTime) {
+      const start = executionInfo.startTime;
+      setElapsed(Date.now() - start);
+
+      intervalRef.current = setInterval(() => {
+        setElapsed(Date.now() - start);
+      }, 100);
+
+      return () => {
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+          intervalRef.current = null;
+        }
+      };
+    } else {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    }
+  }, [state, executionInfo?.startTime]);
+
+  const displayTime =
+    state === "executing"
+      ? formatDuration(elapsed)
+      : result?.executionTimeMs
+        ? formatDuration(result.executionTimeMs)
+        : null;
+
+  const rowCount = result?.totalRows ?? result?.rows.length ?? 0;
+
+  return (
+    <div className="flex items-center gap-4 border-t border-bg-tertiary bg-bg-secondary px-3 py-1 text-xs">
+      {/* Connection info */}
+      <div className="flex items-center gap-1.5">
+        {tab?.connectionColor && (
+          <div
+            className="h-2 w-2 rounded-full"
+            style={{ backgroundColor: tab.connectionColor }}
+          />
+        )}
+        <span className="text-text-secondary">
+          {connection?.name || connection?.serverName || "Disconnected"}
+          {tab?.database ? ` · ${tab.database}` : ""}
+        </span>
+      </div>
+
+      <div className="flex-1" />
+
+      {/* Execution state */}
+      <span className={STATE_COLORS[state]}>{STATE_LABELS[state]}</span>
+
+      {/* Execution time */}
+      {displayTime && (
+        <span className="text-text-secondary">{displayTime}</span>
+      )}
+
+      {/* Row count */}
+      {(state === "completed" || state === "executing") && (
+        <span className="text-text-secondary">
+          {rowCount.toLocaleString()} row{rowCount !== 1 ? "s" : ""}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const millis = Math.floor(ms % 1000);
+
+  const hh = String(hours).padStart(2, "0");
+  const mm = String(minutes).padStart(2, "0");
+  const ss = String(seconds).padStart(2, "0");
+  const mmm = String(millis).padStart(3, "0");
+
+  return `${hh}:${mm}:${ss}.${mmm}`;
+}

--- a/src/features/query/components/QueryTabBar.tsx
+++ b/src/features/query/components/QueryTabBar.tsx
@@ -1,0 +1,118 @@
+import { useState, useCallback } from "react";
+import { useQueryStore } from "../store/queryStore";
+import { ContextMenu, type ContextMenuItem } from "../../../shared/components/ContextMenu";
+
+export function QueryTabBar() {
+  const { tabs, activeTabId, setActiveTab, removeTab, closeOtherTabs, closeAllTabs } =
+    useQueryStore();
+  const isTabDirty = useQueryStore((s) => s.isTabDirty);
+
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    tabId: string;
+  } | null>(null);
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, tabId: string) => {
+      e.preventDefault();
+      setContextMenu({ x: e.clientX, y: e.clientY, tabId });
+    },
+    []
+  );
+
+  const contextMenuItems: ContextMenuItem[] = contextMenu
+    ? [
+        {
+          type: "action",
+          label: "Close",
+          onClick: () => removeTab(contextMenu.tabId),
+        },
+        {
+          type: "action",
+          label: "Close Others",
+          onClick: () => closeOtherTabs(contextMenu.tabId),
+          disabled: tabs.length <= 1,
+        },
+        {
+          type: "action",
+          label: "Close All",
+          onClick: () => closeAllTabs(),
+          danger: true,
+        },
+      ]
+    : [];
+
+  return (
+    <>
+      <div className="flex items-center border-b border-bg-tertiary bg-bg-secondary">
+        {tabs.map((tab) => {
+          const dirty = isTabDirty(tab.id);
+          const isActive = tab.id === activeTabId;
+
+          return (
+            <div
+              key={tab.id}
+              className={`group flex max-w-[200px] items-center gap-1.5 border-r border-bg-tertiary px-3 py-1.5 text-xs ${
+                isActive
+                  ? "bg-bg-primary text-text-primary"
+                  : "text-text-secondary hover:bg-bg-tertiary"
+              }`}
+              onContextMenu={(e) => handleContextMenu(e, tab.id)}
+            >
+              {tab.connectionColor && (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: tab.connectionColor }}
+                />
+              )}
+              <button
+                className="min-w-0 truncate"
+                onClick={() => setActiveTab(tab.id)}
+                title={`${tab.database} — ${tab.title}`}
+              >
+                {tab.database ? `${tab.database} — ` : ""}
+                {tab.title}
+              </button>
+              {dirty && (
+                <span className="shrink-0 text-text-secondary" title="Unsaved changes">
+                  &bull;
+                </span>
+              )}
+              <button
+                className="ml-0.5 shrink-0 text-text-secondary opacity-0 hover:text-text-primary group-hover:opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeTab(tab.id);
+                }}
+                title="Close tab"
+              >
+                &times;
+              </button>
+            </div>
+          );
+        })}
+
+        <button
+          className="px-2.5 py-1.5 text-sm text-text-secondary hover:bg-bg-tertiary hover:text-text-primary"
+          onClick={() => {
+            // Dispatch a custom event that the app can handle for new tab creation
+            window.dispatchEvent(new CustomEvent("query:new-tab"));
+          }}
+          title="New Query (Ctrl+N)"
+        >
+          +
+        </button>
+      </div>
+
+      {contextMenu && (
+        <ContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          items={contextMenuItems}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/features/query/components/QueryTabBar.tsx
+++ b/src/features/query/components/QueryTabBar.tsx
@@ -2,6 +2,9 @@ import { useState, useCallback } from "react";
 import { useQueryStore } from "../store/queryStore";
 import { ContextMenu, type ContextMenuItem } from "../../../shared/components/ContextMenu";
 
+const isMac = navigator.platform.toUpperCase().includes("MAC");
+const NEW_QUERY_SHORTCUT = isMac ? "⌘+N" : "Ctrl+N";
+
 export function QueryTabBar() {
   const { tabs, activeTabId, setActiveTab, removeTab, closeOtherTabs, closeAllTabs } =
     useQueryStore();
@@ -99,7 +102,7 @@ export function QueryTabBar() {
             // Dispatch a custom event that the app can handle for new tab creation
             window.dispatchEvent(new CustomEvent("query:new-tab"));
           }}
-          title="New Query (Ctrl+N)"
+          title={`New Query (${NEW_QUERY_SHORTCUT})`}
         >
           +
         </button>

--- a/src/features/query/components/QueryToolbar.tsx
+++ b/src/features/query/components/QueryToolbar.tsx
@@ -15,6 +15,10 @@ export function QueryToolbar({
 }: QueryToolbarProps) {
   const executionInfo = useQueryStore((s) => s.executionInfo[tabId]);
   const isExecuting = executionInfo?.state === "executing";
+  // Cancel can only work once the sidecar has sent back a queryId, which
+  // identifies the in-flight SqlCommand to interrupt. Before that, the
+  // Cancel button would be a no-op, so we keep it disabled until ready.
+  const canCancel = isExecuting && executionInfo?.queryId != null;
 
   return (
     <div className="flex items-center gap-1 border-b border-bg-tertiary bg-bg-secondary px-2 py-1">
@@ -46,9 +50,13 @@ export function QueryToolbar({
       {/* Cancel */}
       <button
         onClick={onCancel}
-        disabled={!isExecuting}
+        disabled={!canCancel}
         className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-text-primary hover:bg-bg-tertiary disabled:cursor-not-allowed disabled:opacity-50"
-        title="Cancel Execution"
+        title={
+          isExecuting && !canCancel
+            ? "Starting... (cancel available once the query is registered)"
+            : "Cancel Execution"
+        }
       >
         <span className="text-error">&#9632;</span>
         Cancel

--- a/src/features/query/components/QueryToolbar.tsx
+++ b/src/features/query/components/QueryToolbar.tsx
@@ -1,0 +1,62 @@
+import { useQueryStore } from "../store/queryStore";
+
+interface QueryToolbarProps {
+  tabId: string;
+  onExecute: () => void;
+  onExecuteSelection: () => void;
+  onCancel: () => void;
+}
+
+export function QueryToolbar({
+  tabId,
+  onExecute,
+  onExecuteSelection,
+  onCancel,
+}: QueryToolbarProps) {
+  const executionInfo = useQueryStore((s) => s.executionInfo[tabId]);
+  const isExecuting = executionInfo?.state === "executing";
+
+  return (
+    <div className="flex items-center gap-1 border-b border-bg-tertiary bg-bg-secondary px-2 py-1">
+      {/* Execute */}
+      <button
+        onClick={onExecute}
+        disabled={isExecuting}
+        className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-text-primary hover:bg-bg-tertiary disabled:cursor-not-allowed disabled:opacity-50"
+        title="Execute (F5)"
+      >
+        <span className="text-success">&#9654;</span>
+        Execute
+      </button>
+
+      {/* Execute Selection */}
+      <button
+        onClick={onExecuteSelection}
+        disabled={isExecuting}
+        className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-text-primary hover:bg-bg-tertiary disabled:cursor-not-allowed disabled:opacity-50"
+        title={`Execute Selection (${isMac() ? "⌘" : "Ctrl"}+Shift+E)`}
+      >
+        <span className="text-accent">&#9654;&#124;</span>
+        Selection
+      </button>
+
+      {/* Separator */}
+      <div className="mx-1 h-4 border-l border-bg-tertiary" />
+
+      {/* Cancel */}
+      <button
+        onClick={onCancel}
+        disabled={!isExecuting}
+        className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-text-primary hover:bg-bg-tertiary disabled:cursor-not-allowed disabled:opacity-50"
+        title="Cancel Execution"
+      >
+        <span className="text-error">&#9632;</span>
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+function isMac(): boolean {
+  return navigator.platform.toUpperCase().includes("MAC");
+}

--- a/src/features/query/components/intellisense/SqlCompletionProvider.ts
+++ b/src/features/query/components/intellisense/SqlCompletionProvider.ts
@@ -100,8 +100,18 @@ export class SqlCompletionProvider
     _context: languages.CompletionContext,
     _token: CancellationToken
   ): languages.ProviderResult<languages.CompletionList> {
+    // Read line-level text for immediate context (what keyword preceded the cursor)
     const textUntilPosition = model.getValueInRange({
       startLineNumber: position.lineNumber,
+      startColumn: 1,
+      endLineNumber: position.lineNumber,
+      endColumn: position.column,
+    });
+
+    // Read the full statement (up to cursor) so we can scope columns to
+    // tables actually referenced in this query's FROM/JOIN/UPDATE/INTO clauses.
+    const fullTextUntilCursor = model.getValueInRange({
+      startLineNumber: 1,
       startColumn: 1,
       endLineNumber: position.lineNumber,
       endColumn: position.column,
@@ -150,10 +160,12 @@ export class SqlCompletionProvider
         }
 
         // Check if prefix is a table name → suggest columns for that table
+        // (already scoped to one table, but dedupe defensively in case the
+        // same column name appears across its history/versioned copies)
         const tableColumns = this.metadata.columns.filter(
           (c) => c.tableName.toLowerCase() === prefix.toLowerCase()
         );
-        for (const col of tableColumns) {
+        for (const col of dedupeColumns(tableColumns)) {
           suggestions.push({
             label: col.name,
             kind: 4, // Field
@@ -167,7 +179,9 @@ export class SqlCompletionProvider
       return { suggestions };
     }
 
-    // Table context: suggest tables and views
+    // Table context: suggest tables and views (schema-qualified only — the
+    // unqualified variant just doubled every entry in the popup without
+    // adding real value).
     if (isTableContext && this.metadata) {
       for (const t of this.metadata.tables) {
         suggestions.push({
@@ -177,25 +191,27 @@ export class SqlCompletionProvider
           insertText: `[${t.schema}].[${t.name}]`,
           range,
         });
-        // Also suggest without schema for convenience
-        suggestions.push({
-          label: t.name,
-          kind: t.type === "view" ? 1 : 2,
-          detail: `${t.schema} · ${t.type}`,
-          insertText: t.name,
-          range,
-          sortText: `1_${t.name}`,
-        });
       }
     }
 
-    // Column context: suggest all columns
+    // Column context: suggest columns ONLY from tables referenced in
+    // this query's FROM/JOIN/UPDATE/INTO clauses. If the parser can't
+    // find any referenced tables (e.g. cursor is before FROM), we fall
+    // back to showing all columns deduped by name.
     if (isColumnContext && this.metadata) {
-      for (const col of this.metadata.columns) {
+      const referencedTables = extractReferencedTables(fullTextUntilCursor);
+      const scopedColumns =
+        referencedTables.size > 0
+          ? this.metadata.columns.filter((c) =>
+              referencedTables.has(c.tableName.toLowerCase())
+            )
+          : this.metadata.columns;
+
+      for (const col of dedupeColumns(scopedColumns)) {
         suggestions.push({
           label: col.name,
           kind: 4, // Field
-          detail: `${col.dataType} — ${col.tableName}`,
+          detail: col.detail,
           insertText: col.name,
           range,
           sortText: `0_${col.name}`,
@@ -257,4 +273,136 @@ export class SqlCompletionProvider
 
     return { suggestions };
   }
+}
+
+/**
+ * Parse SQL text and return the set of table names referenced in
+ * FROM, JOIN, UPDATE, and INTO clauses. Table names are returned lowercased.
+ *
+ * Handles:
+ *   - FROM [schema].[table]           → table
+ *   - FROM schema.table               → table
+ *   - FROM [table]                    → table
+ *   - FROM table                      → table
+ *   - FROM [db].[schema].[table]      → table
+ *   - Multiple tables separated by commas
+ *   - JOIN (all variants: INNER, LEFT, RIGHT, CROSS, FULL, OUTER)
+ *
+ * This is intentionally a regex, not a real parser — it's good enough for
+ * scoping completion suggestions, not SQL validation.
+ */
+function extractReferencedTables(sql: string): Set<string> {
+  const tables = new Set<string>();
+
+  // Strip line comments and block comments so we don't match keywords inside them
+  const clean = sql
+    .replace(/--[^\n]*/g, " ")
+    .replace(/\/\*[\s\S]*?\*\//g, " ");
+
+  // Match: (FROM | JOIN | UPDATE | INTO) followed by one or more table refs.
+  // A table ref can be [bracketed] or bare, optionally prefixed with
+  // schema/database qualifiers. Capture everything until we hit whitespace,
+  // a comma, an open paren, or another keyword.
+  const keywordPattern =
+    /\b(?:FROM|JOIN|UPDATE|INTO)\s+([\s\S]*?)(?=\b(?:WHERE|GROUP|ORDER|HAVING|ON|SET|VALUES|SELECT|UNION|EXCEPT|INTERSECT|WITH|OPTION|FOR|GO|;)\b|$)/gi;
+
+  let match: RegExpExecArray | null;
+  while ((match = keywordPattern.exec(clean)) !== null) {
+    const clause = match[1];
+    // Within a FROM/JOIN clause, tables may be comma-separated. Split on commas
+    // at the top level (ignoring brackets).
+    for (const ref of splitTableRefs(clause)) {
+      const tableName = extractTableName(ref);
+      if (tableName) {
+        tables.add(tableName.toLowerCase());
+      }
+    }
+  }
+
+  return tables;
+}
+
+/** Split a FROM/JOIN clause body on top-level commas. */
+function splitTableRefs(clause: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of clause) {
+    if (ch === "[" || ch === "(") depth++;
+    else if (ch === "]" || ch === ")") depth--;
+    else if (ch === "," && depth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) parts.push(current);
+  return parts;
+}
+
+/**
+ * Extract just the table name from a reference like:
+ *   "[WideWorldImporters].[Application].[Cities] c"  → "Cities"
+ *   "dbo.Orders AS o"                                → "Orders"
+ *   "Customers"                                      → "Customers"
+ * Returns null if the reference is a subquery or otherwise can't be parsed.
+ */
+function extractTableName(ref: string): string | null {
+  const trimmed = ref.trim();
+  if (!trimmed || trimmed.startsWith("(")) return null;
+
+  // Take the first token (before any whitespace — skips aliases, AS keyword, etc.)
+  const firstToken = trimmed.split(/\s+/)[0];
+
+  // Split on dots to handle [db].[schema].[table] or schema.table
+  // Strip brackets from each part.
+  const parts = firstToken
+    .split(".")
+    .map((p) => p.replace(/^\[|\]$/g, ""))
+    .filter((p) => p.length > 0);
+
+  if (parts.length === 0) return null;
+  return parts[parts.length - 1];
+}
+
+interface DedupedColumn {
+  name: string;
+  detail: string;
+  tableName: string;
+  dataType: string;
+}
+
+/**
+ * Collapse columns that share a name (e.g. `CityName` exists in `Cities`,
+ * `Cities_Archive`, views, etc.) into a single completion entry. The detail
+ * string surfaces the first table and, when relevant, how many others also
+ * have the column so the popup isn't flooded with near-identical rows.
+ */
+function dedupeColumns(
+  columns: Array<{ name: string; tableName: string; dataType: string }>
+): DedupedColumn[] {
+  const byName = new Map<string, { dataType: string; tables: string[] }>();
+  for (const col of columns) {
+    const existing = byName.get(col.name);
+    if (existing) {
+      if (!existing.tables.includes(col.tableName)) {
+        existing.tables.push(col.tableName);
+      }
+    } else {
+      byName.set(col.name, { dataType: col.dataType, tables: [col.tableName] });
+    }
+  }
+
+  const result: DedupedColumn[] = [];
+  for (const [name, info] of byName) {
+    const first = info.tables[0];
+    const extra = info.tables.length - 1;
+    const detail =
+      extra > 0
+        ? `${info.dataType} — ${first} (+${extra} more)`
+        : `${info.dataType} — ${first}`;
+    result.push({ name, detail, tableName: first, dataType: info.dataType });
+  }
+  return result;
 }

--- a/src/features/query/components/intellisense/SqlCompletionProvider.ts
+++ b/src/features/query/components/intellisense/SqlCompletionProvider.ts
@@ -1,0 +1,260 @@
+import type { languages, editor, Position, CancellationToken } from "monaco-editor";
+import type { IntelliSenseMetadata } from "../../api/queryApi";
+
+/** T-SQL keywords for autocomplete */
+const TSQL_KEYWORDS = [
+  "SELECT", "FROM", "WHERE", "INSERT", "INTO", "UPDATE", "DELETE",
+  "SET", "VALUES", "JOIN", "INNER", "LEFT", "RIGHT", "OUTER", "CROSS",
+  "ON", "AND", "OR", "NOT", "IN", "EXISTS", "BETWEEN", "LIKE",
+  "IS", "NULL", "AS", "ORDER", "BY", "GROUP", "HAVING",
+  "DISTINCT", "TOP", "WITH", "UNION", "ALL", "EXCEPT", "INTERSECT",
+  "CREATE", "ALTER", "DROP", "TABLE", "VIEW", "INDEX", "PROCEDURE",
+  "FUNCTION", "TRIGGER", "DATABASE", "SCHEMA",
+  "BEGIN", "END", "IF", "ELSE", "WHILE", "RETURN", "DECLARE",
+  "EXEC", "EXECUTE", "PRINT", "RAISERROR", "THROW",
+  "TRY", "CATCH", "TRANSACTION", "COMMIT", "ROLLBACK", "SAVE",
+  "GO", "USE", "GRANT", "REVOKE", "DENY",
+  "ASC", "DESC", "CASE", "WHEN", "THEN", "CAST", "CONVERT",
+  "COALESCE", "ISNULL", "NULLIF", "COUNT", "SUM", "AVG", "MIN", "MAX",
+  "LEN", "SUBSTRING", "REPLACE", "TRIM", "LTRIM", "RTRIM",
+  "GETDATE", "DATEADD", "DATEDIFF", "YEAR", "MONTH", "DAY",
+  "IDENTITY", "PRIMARY", "KEY", "FOREIGN", "REFERENCES", "CONSTRAINT",
+  "DEFAULT", "CHECK", "UNIQUE", "CLUSTERED", "NONCLUSTERED",
+  "WAITFOR", "DELAY", "OPENQUERY", "OPENROWSET",
+];
+
+/** Common T-SQL snippets */
+const TSQL_SNIPPETS: Array<{
+  label: string;
+  insertText: string;
+  detail: string;
+}> = [
+  {
+    label: "SELECT TOP",
+    insertText: "SELECT TOP ${1:100} *\nFROM ${2:tableName}",
+    detail: "SELECT TOP N * FROM table",
+  },
+  {
+    label: "INSERT INTO",
+    insertText: "INSERT INTO ${1:tableName} (${2:columns})\nVALUES (${3:values})",
+    detail: "INSERT INTO table (cols) VALUES (vals)",
+  },
+  {
+    label: "UPDATE SET",
+    insertText: "UPDATE ${1:tableName}\nSET ${2:column} = ${3:value}\nWHERE ${4:condition}",
+    detail: "UPDATE table SET col = val WHERE ...",
+  },
+  {
+    label: "DELETE FROM",
+    insertText: "DELETE FROM ${1:tableName}\nWHERE ${2:condition}",
+    detail: "DELETE FROM table WHERE ...",
+  },
+  {
+    label: "BEGIN TRAN",
+    insertText: "BEGIN TRANSACTION\n\t${1:-- statements}\nCOMMIT TRANSACTION",
+    detail: "BEGIN TRANSACTION ... COMMIT",
+  },
+  {
+    label: "IF EXISTS DROP",
+    insertText:
+      "IF EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'${1:objectName}'))\n\tDROP ${2:TABLE} ${1:objectName}",
+    detail: "IF EXISTS ... DROP object",
+  },
+  {
+    label: "TRY CATCH",
+    insertText:
+      "BEGIN TRY\n\t${1:-- statements}\nEND TRY\nBEGIN CATCH\n\tSELECT ERROR_MESSAGE() AS ErrorMessage\nEND CATCH",
+    detail: "BEGIN TRY ... END CATCH",
+  },
+  {
+    label: "CTE",
+    insertText:
+      ";WITH ${1:cteName} AS (\n\t${2:SELECT 1}\n)\nSELECT *\nFROM ${1:cteName}",
+    detail: "Common Table Expression",
+  },
+];
+
+/** Context keywords that suggest table completions follow */
+const TABLE_CONTEXT_KEYWORDS = /\b(FROM|JOIN|INTO|UPDATE|TABLE|INNER\s+JOIN|LEFT\s+JOIN|RIGHT\s+JOIN|CROSS\s+JOIN|LEFT\s+OUTER\s+JOIN|RIGHT\s+OUTER\s+JOIN|FULL\s+OUTER\s+JOIN)\s+$/i;
+
+/** Context keywords that suggest column completions follow */
+const COLUMN_CONTEXT_KEYWORDS = /\b(SELECT|WHERE|ON|SET|BY|HAVING|AND|OR)\s+$/i;
+
+/** Context keywords that suggest procedure completions follow */
+const PROC_CONTEXT_KEYWORDS = /\b(EXEC|EXECUTE)\s+$/i;
+
+export class SqlCompletionProvider
+  implements languages.CompletionItemProvider
+{
+  triggerCharacters = [".", " "];
+
+  private metadata: IntelliSenseMetadata | null = null;
+
+  setMetadata(metadata: IntelliSenseMetadata | null): void {
+    this.metadata = metadata;
+  }
+
+  provideCompletionItems(
+    model: editor.ITextModel,
+    position: Position,
+    _context: languages.CompletionContext,
+    _token: CancellationToken
+  ): languages.ProviderResult<languages.CompletionList> {
+    const textUntilPosition = model.getValueInRange({
+      startLineNumber: position.lineNumber,
+      startColumn: 1,
+      endLineNumber: position.lineNumber,
+      endColumn: position.column,
+    });
+
+    const word = model.getWordUntilPosition(position);
+    const range = {
+      startLineNumber: position.lineNumber,
+      startColumn: word.startColumn,
+      endLineNumber: position.lineNumber,
+      endColumn: word.endColumn,
+    };
+
+    const suggestions: languages.CompletionItem[] = [];
+
+    // Check context for smart completions
+    const textBefore = textUntilPosition.substring(
+      0,
+      textUntilPosition.length - word.word.length
+    );
+
+    const isTableContext = TABLE_CONTEXT_KEYWORDS.test(textBefore);
+    const isColumnContext = COLUMN_CONTEXT_KEYWORDS.test(textBefore);
+    const isProcContext = PROC_CONTEXT_KEYWORDS.test(textBefore);
+
+    // After a dot — could be schema.table or table.column
+    if (textBefore.endsWith(".")) {
+      const dotParts = textBefore.trimEnd().split(/\s+/).pop() ?? "";
+      const prefix = dotParts.replace(/\.$/, "");
+
+      if (this.metadata) {
+        // Check if prefix is a schema name → suggest tables in that schema
+        const schemaTables = this.metadata.tables.filter(
+          (t) => t.schema.toLowerCase() === prefix.toLowerCase()
+        );
+        if (schemaTables.length > 0) {
+          for (const t of schemaTables) {
+            suggestions.push({
+              label: t.name,
+              kind: t.type === "view" ? 1 : 2, // Module=1 for views, Struct=2 for tables
+              detail: `${t.schema}.${t.name} (${t.type})`,
+              insertText: t.name,
+              range,
+            });
+          }
+        }
+
+        // Check if prefix is a table name → suggest columns for that table
+        const tableColumns = this.metadata.columns.filter(
+          (c) => c.tableName.toLowerCase() === prefix.toLowerCase()
+        );
+        for (const col of tableColumns) {
+          suggestions.push({
+            label: col.name,
+            kind: 4, // Field
+            detail: `${col.dataType} — ${col.tableName}`,
+            insertText: col.name,
+            range,
+          });
+        }
+      }
+
+      return { suggestions };
+    }
+
+    // Table context: suggest tables and views
+    if (isTableContext && this.metadata) {
+      for (const t of this.metadata.tables) {
+        suggestions.push({
+          label: `${t.schema}.${t.name}`,
+          kind: t.type === "view" ? 1 : 2,
+          detail: t.type,
+          insertText: `[${t.schema}].[${t.name}]`,
+          range,
+        });
+        // Also suggest without schema for convenience
+        suggestions.push({
+          label: t.name,
+          kind: t.type === "view" ? 1 : 2,
+          detail: `${t.schema} · ${t.type}`,
+          insertText: t.name,
+          range,
+          sortText: `1_${t.name}`,
+        });
+      }
+    }
+
+    // Column context: suggest all columns
+    if (isColumnContext && this.metadata) {
+      for (const col of this.metadata.columns) {
+        suggestions.push({
+          label: col.name,
+          kind: 4, // Field
+          detail: `${col.dataType} — ${col.tableName}`,
+          insertText: col.name,
+          range,
+          sortText: `0_${col.name}`,
+        });
+      }
+    }
+
+    // Procedure context
+    if (isProcContext && this.metadata) {
+      for (const p of this.metadata.procedures) {
+        suggestions.push({
+          label: `${p.schema}.${p.name}`,
+          kind: 1, // Function
+          detail: "stored procedure",
+          insertText: `[${p.schema}].[${p.name}]`,
+          range,
+        });
+      }
+    }
+
+    // Functions (always available)
+    if (this.metadata) {
+      for (const f of this.metadata.functions) {
+        suggestions.push({
+          label: `${f.schema}.${f.name}`,
+          kind: 1, // Function
+          detail: `${f.type} function`,
+          insertText: `[${f.schema}].[${f.name}]()`,
+          range,
+          sortText: `3_${f.name}`,
+        });
+      }
+    }
+
+    // T-SQL keywords (always available, lower priority)
+    for (const kw of TSQL_KEYWORDS) {
+      suggestions.push({
+        label: kw,
+        kind: 13, // Keyword
+        detail: "keyword",
+        insertText: kw,
+        range,
+        sortText: `9_${kw}`,
+      });
+    }
+
+    // Snippets (always available)
+    for (const snippet of TSQL_SNIPPETS) {
+      suggestions.push({
+        label: snippet.label,
+        kind: 24, // Snippet
+        detail: snippet.detail,
+        insertText: snippet.insertText,
+        insertTextRules: 4, // InsertAsSnippet
+        range,
+        sortText: `8_${snippet.label}`,
+      });
+    }
+
+    return { suggestions };
+  }
+}

--- a/src/features/query/index.ts
+++ b/src/features/query/index.ts
@@ -1,6 +1,7 @@
 export { useQueryStore } from "./store/queryStore";
 export { QueryPanel } from "./components/QueryPanel";
 export { QueryTabBar } from "./components/QueryTabBar";
+export { initQueryEventListeners } from "./api/queryEventListeners";
 export type {
   QueryTab,
   QueryColumn,

--- a/src/features/query/index.ts
+++ b/src/features/query/index.ts
@@ -1,2 +1,10 @@
 export { useQueryStore } from "./store/queryStore";
-export type { QueryTab } from "./types";
+export { QueryPanel } from "./components/QueryPanel";
+export { QueryTabBar } from "./components/QueryTabBar";
+export type {
+  QueryTab,
+  QueryColumn,
+  QueryMessage,
+  QueryResult,
+  QueryExecutionState,
+} from "./types";

--- a/src/features/query/store/queryStore.ts
+++ b/src/features/query/store/queryStore.ts
@@ -1,30 +1,112 @@
 import { create } from "zustand";
-import type { QueryTab } from "../types";
+import type {
+  QueryTab,
+  QueryExecutionState,
+  QueryResult,
+  QueryBatchPayload,
+  QueryColumn,
+  QueryMessage,
+} from "../types";
+import {
+  queryExecute,
+  queryCancel,
+  intellisenseGetMetadata,
+  type IntelliSenseMetadata,
+} from "../api/queryApi";
+
+interface TabExecutionInfo {
+  state: QueryExecutionState;
+  queryId: string | null;
+  requestId: string | null;
+  startTime: number | null;
+}
 
 interface QueryState {
   tabs: QueryTab[];
   activeTabId: string | null;
+  tabSql: Record<string, string>;
+  executionInfo: Record<string, TabExecutionInfo>;
+  results: Record<string, QueryResult>;
+  intellisenseCache: Record<string, IntelliSenseMetadata>;
 
+  // Tab management
   addTab: (tab: QueryTab) => void;
   removeTab: (id: string) => void;
   setActiveTab: (id: string) => void;
+  updateSql: (tabId: string, sql: string) => void;
+  reorderTabs: (fromIndex: number, toIndex: number) => void;
+  closeOtherTabs: (tabId: string) => void;
+  closeAllTabs: () => void;
+
+  // Query execution
+  executeQuery: (tabId: string, sql?: string) => Promise<void>;
+  cancelQuery: (tabId: string) => Promise<void>;
+
+  // Streaming event handlers
+  handleResultsBatch: (payload: QueryBatchPayload) => void;
+  handleQueryComplete: (payload: QueryBatchPayload) => void;
+  handleQueryError: (queryIdOrRequestId: string, error: string) => void;
+
+  // IntelliSense
+  loadIntelliSense: (connectionId: string, database: string) => Promise<IntelliSenseMetadata | null>;
+
+  // Helpers
+  getTabExecutionState: (tabId: string) => QueryExecutionState;
+  isTabDirty: (tabId: string) => boolean;
 }
 
-export const useQueryStore = create<QueryState>((set) => ({
+function emptyResult(): QueryResult {
+  return {
+    columns: [],
+    rows: [],
+    messages: [],
+    executionTimeMs: 0,
+    totalRows: 0,
+  };
+}
+
+/** Find the tab that owns a given queryId or requestId */
+function findTabByQueryOrRequest(
+  executionInfo: Record<string, TabExecutionInfo>,
+  id: string
+): string | null {
+  for (const [tabId, info] of Object.entries(executionInfo)) {
+    if (info.queryId === id || info.requestId === id) {
+      return tabId;
+    }
+  }
+  return null;
+}
+
+export const useQueryStore = create<QueryState>((set, get) => ({
   tabs: [],
   activeTabId: null,
+  tabSql: {},
+  executionInfo: {},
+  results: {},
+  intellisenseCache: {},
 
   addTab: (tab) =>
     set((state) => ({
       tabs: [...state.tabs, tab],
       activeTabId: tab.id,
+      tabSql: {
+        ...state.tabSql,
+        [tab.id]: tab.initialSql ?? "",
+      },
     })),
 
   removeTab: (id) =>
     set((state) => {
       const tabs = state.tabs.filter((t) => t.id !== id);
+      const { [id]: _sql, ...restSql } = state.tabSql;
+      const { [id]: _exec, ...restExec } = state.executionInfo;
+      const { [id]: _res, ...restResults } = state.results;
       return {
         tabs,
+        tabSql: restSql,
+        executionInfo: restExec,
+        results: restResults,
         activeTabId:
           state.activeTabId === id
             ? tabs.length > 0
@@ -35,4 +117,287 @@ export const useQueryStore = create<QueryState>((set) => ({
     }),
 
   setActiveTab: (id) => set({ activeTabId: id }),
+
+  updateSql: (tabId, sql) =>
+    set((state) => ({
+      tabSql: { ...state.tabSql, [tabId]: sql },
+    })),
+
+  reorderTabs: (fromIndex, toIndex) =>
+    set((state) => {
+      const tabs = [...state.tabs];
+      const [moved] = tabs.splice(fromIndex, 1);
+      tabs.splice(toIndex, 0, moved);
+      return { tabs };
+    }),
+
+  closeOtherTabs: (tabId) =>
+    set((state) => {
+      const kept = state.tabs.filter((t) => t.id === tabId);
+      const removedIds = state.tabs
+        .filter((t) => t.id !== tabId)
+        .map((t) => t.id);
+
+      const tabSql = { ...state.tabSql };
+      const executionInfo = { ...state.executionInfo };
+      const results = { ...state.results };
+      for (const id of removedIds) {
+        delete tabSql[id];
+        delete executionInfo[id];
+        delete results[id];
+      }
+
+      return {
+        tabs: kept,
+        activeTabId: tabId,
+        tabSql,
+        executionInfo,
+        results,
+      };
+    }),
+
+  closeAllTabs: () =>
+    set({
+      tabs: [],
+      activeTabId: null,
+      tabSql: {},
+      executionInfo: {},
+      results: {},
+    }),
+
+  executeQuery: async (tabId, sql) => {
+    const state = get();
+    const tab = state.tabs.find((t) => t.id === tabId);
+    if (!tab) {
+      console.error(`Cannot execute query: tab '${tabId}' not found`);
+      return;
+    }
+
+    const queryText = sql ?? state.tabSql[tabId] ?? "";
+    if (!queryText.trim()) {
+      return;
+    }
+
+    // Set executing state and clear previous results
+    set((s) => ({
+      executionInfo: {
+        ...s.executionInfo,
+        [tabId]: {
+          state: "executing",
+          queryId: null,
+          requestId: null,
+          startTime: Date.now(),
+        },
+      },
+      results: {
+        ...s.results,
+        [tabId]: emptyResult(),
+      },
+    }));
+
+    try {
+      const response = await queryExecute(
+        tab.connectionId,
+        tab.database,
+        queryText
+      );
+
+      // Store the requestId so we can match streaming events
+      set((s) => ({
+        executionInfo: {
+          ...s.executionInfo,
+          [tabId]: {
+            ...s.executionInfo[tabId],
+            requestId: response.requestId,
+          },
+        },
+      }));
+    } catch (e) {
+      console.error(`Query execution failed for tab '${tabId}':`, e);
+      set((s) => ({
+        executionInfo: {
+          ...s.executionInfo,
+          [tabId]: {
+            ...s.executionInfo[tabId],
+            state: "failed",
+            startTime: null,
+          },
+        },
+        results: {
+          ...s.results,
+          [tabId]: {
+            ...emptyResult(),
+            messages: [
+              {
+                text: String(e),
+                severity: "error" as const,
+              },
+            ],
+          },
+        },
+      }));
+    }
+  },
+
+  cancelQuery: async (tabId) => {
+    const info = get().executionInfo[tabId];
+    if (!info?.queryId) {
+      console.warn(`Cannot cancel query for tab '${tabId}': no active queryId`);
+      return;
+    }
+
+    try {
+      await queryCancel(info.queryId);
+    } catch (e) {
+      console.error(`Failed to cancel query for tab '${tabId}':`, e);
+    }
+  },
+
+  handleResultsBatch: (payload) => {
+    const tabId = findTabByQueryOrRequest(get().executionInfo, payload.queryId);
+    if (!tabId) return;
+
+    set((s) => {
+      const existing = s.results[tabId] ?? emptyResult();
+      const newColumns: QueryColumn[] =
+        payload.columns && payload.columns.length > 0
+          ? payload.columns
+          : existing.columns;
+      const newRows = [...existing.rows, ...(payload.rows ?? [])];
+      const newMessages = [
+        ...existing.messages,
+        ...(payload.messages ?? []),
+      ];
+
+      return {
+        executionInfo: {
+          ...s.executionInfo,
+          [tabId]: {
+            ...s.executionInfo[tabId],
+            queryId: payload.queryId,
+          },
+        },
+        results: {
+          ...s.results,
+          [tabId]: {
+            columns: newColumns,
+            rows: newRows,
+            messages: newMessages,
+            executionTimeMs: payload.executionTimeMs ?? existing.executionTimeMs,
+            totalRows: newRows.length,
+          },
+        },
+      };
+    });
+  },
+
+  handleQueryComplete: (payload) => {
+    const tabId = findTabByQueryOrRequest(get().executionInfo, payload.queryId);
+    if (!tabId) return;
+
+    set((s) => {
+      const existing = s.results[tabId] ?? emptyResult();
+      const newRows = [...existing.rows, ...(payload.rows ?? [])];
+      const finalMessages: QueryMessage[] = [
+        ...existing.messages,
+        ...(payload.messages ?? []),
+      ];
+
+      const isCancelled = finalMessages.some(
+        (m) =>
+          m.text.toLowerCase().includes("cancelled") ||
+          m.text.toLowerCase().includes("canceled")
+      );
+
+      return {
+        executionInfo: {
+          ...s.executionInfo,
+          [tabId]: {
+            ...s.executionInfo[tabId],
+            state: isCancelled ? "cancelled" : "completed",
+            startTime: null,
+          },
+        },
+        results: {
+          ...s.results,
+          [tabId]: {
+            columns:
+              payload.columns && payload.columns.length > 0
+                ? payload.columns
+                : existing.columns,
+            rows: newRows,
+            messages: finalMessages,
+            executionTimeMs:
+              payload.executionTimeMs ?? existing.executionTimeMs,
+            totalRows: payload.totalRows ?? newRows.length,
+          },
+        },
+      };
+    });
+  },
+
+  handleQueryError: (queryIdOrRequestId, error) => {
+    const tabId = findTabByQueryOrRequest(
+      get().executionInfo,
+      queryIdOrRequestId
+    );
+    if (!tabId) return;
+
+    set((s) => {
+      const existing = s.results[tabId] ?? emptyResult();
+      return {
+        executionInfo: {
+          ...s.executionInfo,
+          [tabId]: {
+            ...s.executionInfo[tabId],
+            state: "failed",
+            startTime: null,
+          },
+        },
+        results: {
+          ...s.results,
+          [tabId]: {
+            ...existing,
+            messages: [
+              ...existing.messages,
+              { text: error, severity: "error" as const },
+            ],
+          },
+        },
+      };
+    });
+  },
+
+  loadIntelliSense: async (connectionId, database) => {
+    const cacheKey = `${connectionId}:${database}`;
+    const cached = get().intellisenseCache[cacheKey];
+    if (cached) return cached;
+
+    try {
+      const metadata = await intellisenseGetMetadata(connectionId, database);
+      set((s) => ({
+        intellisenseCache: {
+          ...s.intellisenseCache,
+          [cacheKey]: metadata,
+        },
+      }));
+      return metadata;
+    } catch (e) {
+      console.error(
+        `Failed to load IntelliSense for ${connectionId}/${database}:`,
+        e
+      );
+      return null;
+    }
+  },
+
+  getTabExecutionState: (tabId) => {
+    return get().executionInfo[tabId]?.state ?? "idle";
+  },
+
+  isTabDirty: (tabId) => {
+    const tab = get().tabs.find((t) => t.id === tabId);
+    const sql = get().tabSql[tabId] ?? "";
+    return sql !== (tab?.initialSql ?? "");
+  },
 }));

--- a/src/features/query/store/queryStore.ts
+++ b/src/features/query/store/queryStore.ts
@@ -45,7 +45,7 @@ interface QueryState {
   // Streaming event handlers
   handleResultsBatch: (payload: QueryBatchPayload) => void;
   handleQueryComplete: (payload: QueryBatchPayload) => void;
-  handleQueryError: (queryIdOrRequestId: string, error: string) => void;
+  handleQueryError: (queryId: string | undefined, requestId: string | undefined, error: string) => void;
 
   // IntelliSense
   loadIntelliSense: (connectionId: string, database: string) => Promise<IntelliSenseMetadata | null>;
@@ -65,14 +65,18 @@ function emptyResult(): QueryResult {
   };
 }
 
-/** Find the tab that owns a given queryId or requestId */
-function findTabByQueryOrRequest(
+/** Find the tab that owns a given queryId or requestId.
+ *  Accepts multiple IDs to try (e.g. both queryId and requestId from the payload). */
+function findTabByIds(
   executionInfo: Record<string, TabExecutionInfo>,
-  id: string
+  ...ids: (string | undefined | null)[]
 ): string | null {
+  const candidates = ids.filter((id): id is string => typeof id === "string" && id.length > 0);
   for (const [tabId, info] of Object.entries(executionInfo)) {
-    if (info.queryId === id || info.requestId === id) {
-      return tabId;
+    for (const id of candidates) {
+      if (info.queryId === id || info.requestId === id) {
+        return tabId;
+      }
     }
   }
   return null;
@@ -254,7 +258,7 @@ export const useQueryStore = create<QueryState>((set, get) => ({
   },
 
   handleResultsBatch: (payload) => {
-    const tabId = findTabByQueryOrRequest(get().executionInfo, payload.queryId);
+    const tabId = findTabByIds(get().executionInfo, payload.queryId, payload.requestId);
     if (!tabId) return;
 
     set((s) => {
@@ -292,7 +296,7 @@ export const useQueryStore = create<QueryState>((set, get) => ({
   },
 
   handleQueryComplete: (payload) => {
-    const tabId = findTabByQueryOrRequest(get().executionInfo, payload.queryId);
+    const tabId = findTabByIds(get().executionInfo, payload.queryId, payload.requestId);
     if (!tabId) return;
 
     set((s) => {
@@ -336,10 +340,11 @@ export const useQueryStore = create<QueryState>((set, get) => ({
     });
   },
 
-  handleQueryError: (queryIdOrRequestId, error) => {
-    const tabId = findTabByQueryOrRequest(
+  handleQueryError: (queryId, requestId, error) => {
+    const tabId = findTabByIds(
       get().executionInfo,
-      queryIdOrRequestId
+      queryId,
+      requestId
     );
     if (!tabId) return;
 

--- a/src/features/query/store/queryStore.ts
+++ b/src/features/query/store/queryStore.ts
@@ -177,19 +177,34 @@ export const useQueryStore = create<QueryState>((set, get) => ({
       return;
     }
 
+    // Guard against re-entry: F5/menu/toolbar can all trigger executeQuery,
+    // and restarting mid-run would orphan the in-flight query in the sidecar
+    // (its results would no longer be attributable to the tab).
+    if (state.executionInfo[tabId]?.state === "executing") {
+      console.warn(
+        `Ignoring executeQuery for tab '${tabId}': already executing. Cancel first.`
+      );
+      return;
+    }
+
     const queryText = sql ?? state.tabSql[tabId] ?? "";
     if (!queryText.trim()) {
       return;
     }
 
-    // Set executing state and clear previous results
+    // Generate the requestId client-side and store it BEFORE calling invoke.
+    // This closes the race where streaming events (e.g. the sidecar's
+    // immediate "started" batch) could arrive before the frontend knew
+    // which tab the requestId belonged to.
+    const requestId = crypto.randomUUID();
+
     set((s) => ({
       executionInfo: {
         ...s.executionInfo,
         [tabId]: {
           state: "executing",
           queryId: null,
-          requestId: null,
+          requestId,
           startTime: Date.now(),
         },
       },
@@ -200,22 +215,8 @@ export const useQueryStore = create<QueryState>((set, get) => ({
     }));
 
     try {
-      const response = await queryExecute(
-        tab.connectionId,
-        tab.database,
-        queryText
-      );
-
-      // Store the requestId so we can match streaming events
-      set((s) => ({
-        executionInfo: {
-          ...s.executionInfo,
-          [tabId]: {
-            ...s.executionInfo[tabId],
-            requestId: response.requestId,
-          },
-        },
-      }));
+      await queryExecute(requestId, tab.connectionId, tab.database, queryText);
+      // requestId is already in executionInfo — no follow-up set needed
     } catch (e) {
       console.error(`Query execution failed for tab '${tabId}':`, e);
       set((s) => ({

--- a/src/features/query/types.ts
+++ b/src/features/query/types.ts
@@ -1,7 +1,50 @@
+export type QueryExecutionState = "idle" | "executing" | "completed" | "failed" | "cancelled";
+
+export interface QueryColumn {
+  name: string;
+  dataType: string;
+  isNullable: boolean;
+  maxLength?: number;
+}
+
+export interface QueryMessage {
+  text: string;
+  severity: "info" | "error";
+  lineNumber?: number;
+}
+
+export interface QueryResult {
+  columns: QueryColumn[];
+  rows: unknown[][];
+  messages: QueryMessage[];
+  executionTimeMs: number;
+  totalRows: number;
+}
+
 export interface QueryTab {
   id: string;
   connectionId: string;
   database: string;
   initialSql?: string;
   title: string;
+  connectionColor?: string;
+}
+
+/** Payload shape from the sidecar streaming batches */
+export interface QueryBatchPayload {
+  queryId: string;
+  columns?: QueryColumn[];
+  rows?: unknown[][];
+  batch: number;
+  done: boolean;
+  executionTimeMs?: number;
+  totalRows?: number;
+  messages?: QueryMessage[];
+  resultSetIndex?: number;
+}
+
+/** Payload for query:error events */
+export interface QueryErrorPayload {
+  queryId?: string;
+  error: string;
 }

--- a/src/features/query/types.ts
+++ b/src/features/query/types.ts
@@ -30,9 +30,10 @@ export interface QueryTab {
   connectionColor?: string;
 }
 
-/** Payload shape from the sidecar streaming batches */
+/** Payload shape from the sidecar streaming batches (with requestId injected by Rust) */
 export interface QueryBatchPayload {
   queryId: string;
+  requestId?: string;
   columns?: QueryColumn[];
   rows?: unknown[][];
   batch: number;
@@ -46,5 +47,6 @@ export interface QueryBatchPayload {
 /** Payload for query:error events */
 export interface QueryErrorPayload {
   queryId?: string;
+  requestId?: string;
   error: string;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,12 @@ import React, { useEffect } from "react";
 import ReactDOM from "react-dom/client";
 import App from "./app/App";
 import { ErrorBoundary } from "./shared/components/ErrorBoundary";
+import { initQueryEventListeners } from "./features/query";
 import "./index.css";
+
+// Register Tauri query event listeners ONCE at module load, outside of React.
+// Tying them to a component's lifecycle caused React strict mode issues.
+initQueryEventListeners();
 
 function Root() {
   useEffect(() => {


### PR DESCRIPTION
## Summary

Implements M3: Query Editor. Users can now write SQL in Monaco, execute with F5, see results, cancel long queries, and get schema-aware completions — across all three layers (React, Tauri, C# sidecar).

- Monaco integration with SQL language mode, tab management, toolbar (Execute / Selection / Cancel), keyboard shortcuts (F5, ⌘+Shift+E, ⌘+N, ⌘+W), native menu (File / Edit / Query / View), and status bar with live timer and row count.
- Streaming query execution with cooperative cancellation: sidecar streams 5,000-row batches with correlated requestIds, Rust forwards batches as Tauri events, frontend accumulates results per tab.
- IntelliSense powered by cached schema metadata — scoped to tables referenced in the current query's FROM/JOIN/UPDATE/INTO clauses and deduped by column name.

Closes #23, closes #24, closes #25, closes #26, closes #27, closes #28, closes #29, closes #30.

## Test plan

- [ ] Create a new query tab (⌘+N / File > New Query / + in tab bar)
- [ ] `SELECT TOP 1000 * FROM [Application].[Cities]` → F5 shows 1,000 rows
- [ ] Run the same query a second and third time — no duplicate rows, no stuck "Executing" state
- [ ] Execute Selection (⌘+Shift+E) with a highlighted `SELECT 1` runs just that statement
- [ ] Long query (`WAITFOR DELAY '00:00:30'`) → Cancel button stops it mid-flight
- [ ] Query against `Person.Address` (has a `geography` column) returns rows without crashing the sidecar
- [ ] Type `SELECT ` → T-SQL keyword completions appear
- [ ] Type `WHERE cit` in a query scoped to `Cities` → only columns from Cities appear (no CreditLimit from Customers, no duplicate CityName)
- [ ] Type `FROM ` → schema-qualified table/view completions appear
- [ ] Syntax error in SQL → error surfaces in Messages tab, state returns to idle, next execution works
- [ ] Close tab via X, context menu, ⌘+W, or File > Close Tab
- [ ] Editor theme matches system light/dark mode

## Notes

- Sidecar is single-threaded for query execution (queued main loop + dedicated stdin reader). Cancellation is handled on the reader thread so `query.cancel` reaches `SqlCommand.Cancel()` even while the main loop is blocked on a streaming read.
- SQL Server spatial types (geography / geometry / hierarchyid) are read as raw bytes (hex) to avoid depending on `Microsoft.SqlServer.Types`.
- Tauri event listeners are registered once at module load (not in a React effect) to avoid strict-mode corruption of Tauri's internal listener registry.