### PR TITLE
Fix beta release startup polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,7 @@ jobs:
             desc "Fast cross-platform SQL Server Management Studio replacement"
             homepage "https://github.com/gordonbeeming/ssmsx"
 
-            depends_on macos: ">= :sonoma"
+            depends_on macos: :sonoma
 
             app "SSMSx.app"
 


### PR DESCRIPTION
## Summary
- Generate the SSMSx Homebrew cask with the modern symbolic macOS dependency syntax
- Stop the app from auto-opening Web Inspector unless a debug build explicitly sets `SSMSX_OPEN_DEVTOOLS=1`
- Open the connection dialog on first launch after loading saved connections, and remove the large centered empty-state CTA behind it
- Persist the computed release app version across release workflow steps and fail the release if the built macOS app bundle metadata does not match

## Verification
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `actionlint .github/workflows/ci.yml`
- Verified the live tap cask now uses `depends_on macos: :sonoma`; the live tap was updated separately in GordonBeeming/homebrew-tap commit `f1c178e`