### PR TITLE
Fix release startup and devtools behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,8 @@ jobs:
           if [[ "${GITHUB_REF_NAME}" =~ ^v([0-9]+)\.([0-9]+)(-beta\.[0-9]+)?$ ]]; then
             export VERSION="${GITHUB_REF_NAME#v}"
             export APP_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${GITHUB_RUN_NUMBER}${BASH_REMATCH[3]}"
+            echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
+            echo "APP_VERSION=${APP_VERSION}" >> "${GITHUB_ENV}"
           else
             echo "Release tag must be stable v{major}.{minor} or beta v{major}.{minor}-beta.{n}, like v0.1 or v0.1-beta.1; got ${GITHUB_REF_NAME}" >&2
             exit 1
@@ -308,6 +310,18 @@ jobs:
         env:
           APPLE_SIGNING_IDENTITY: "Developer ID Application: Gordon Beeming (89DBN36T4T)"
         run: npm run tauri -- build --bundles app
+
+      - name: Verify release app metadata
+        run: |
+          APP_BUNDLE="src-tauri/target/release/bundle/macos/SSMSx.app"
+          INFO_PLIST="${APP_BUNDLE}/Contents/Info.plist"
+          test -d "${APP_BUNDLE}" || { echo "Release app bundle was not created at ${APP_BUNDLE}." >&2; exit 1; }
+
+          BUNDLE_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "${INFO_PLIST}")"
+          if [ "${BUNDLE_VERSION}" != "${APP_VERSION}" ]; then
+            echo "Expected app bundle version ${APP_VERSION}, got ${BUNDLE_VERSION}." >&2
+            exit 1
+          fi
 
       - name: Sign application
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,7 @@ jobs:
           APP_BUNDLE="src-tauri/target/release/bundle/macos/SSMSx.app"
           INFO_PLIST="${APP_BUNDLE}/Contents/Info.plist"
           test -d "${APP_BUNDLE}" || { echo "Release app bundle was not created at ${APP_BUNDLE}." >&2; exit 1; }
+          test -f "${INFO_PLIST}" || { echo "Release app metadata was not created at ${INFO_PLIST}." >&2; exit 1; }
 
           BUNDLE_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "${INFO_PLIST}")"
           if [ "${BUNDLE_VERSION}" != "${APP_VERSION}" ]; then

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,7 +29,7 @@ pub fn run() {
 
             #[cfg(debug_assertions)]
             {
-                if std::env::var("SSMSX_OPEN_DEVTOOLS").as_deref() == Ok("1") {
+                if std::env::var("SSMSX_OPEN_DEVTOOLS").ok().as_deref() == Some("1") {
                     if let Some(window) = app.get_webview_window("main") {
                         window.open_devtools();
                     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,11 +27,12 @@ pub fn run() {
             // Build application menu
             build_menu(app)?;
 
-            // Auto-open devtools in debug builds
             #[cfg(debug_assertions)]
             {
-                if let Some(window) = app.get_webview_window("main") {
-                    window.open_devtools();
+                if std::env::var("SSMSX_OPEN_DEVTOOLS").as_deref() == Ok("1") {
+                    if let Some(window) = app.get_webview_window("main") {
+                        window.open_devtools();
+                    }
                 }
             }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -82,6 +82,7 @@ function App() {
 
     const initialize = async () => {
       const queryStore = useQueryStore.getState();
+      const connectionStore = useConnectionStore.getState();
       const persistTabs =
         useSettingsStore.getState().settings.workspace.persistQueryTabs;
       if (!persistTabs) {
@@ -92,11 +93,13 @@ function App() {
       tabCounter = Math.max(tabCounter, getHighestQueryNumber(queryStore.tabs));
 
       if (!restored) {
-        useConnectionStore.getState().openDialog();
+        await connectionStore.loadConnections();
+        window.requestAnimationFrame(() => {
+          useConnectionStore.getState().openDialog();
+        });
         return;
       }
 
-      const connectionStore = useConnectionStore.getState();
       await connectionStore.loadConnections();
 
       const restoredConnectionIds = Array.from(
@@ -136,6 +139,15 @@ function App() {
             }
           }
         }
+      }
+
+      if (
+        useQueryStore.getState().tabs.length === 0 &&
+        useConnectionStore.getState().activeConnectionIds.length === 0
+      ) {
+        window.requestAnimationFrame(() => {
+          useConnectionStore.getState().openDialog();
+        });
       }
     };
 
@@ -410,17 +422,7 @@ function App() {
           ) : (
             <div className="flex flex-1 items-center justify-center overflow-auto">
               {!hasConnections ? (
-                <div className="text-center">
-                  <p className="text-lg text-text-secondary">
-                    Connect to a SQL Server to get started
-                  </p>
-                  <button
-                    onClick={openDialog}
-                    className="mt-4 rounded bg-accent px-6 py-2 text-accent-text hover:bg-accent-hover"
-                  >
-                    New Connection
-                  </button>
-                </div>
+                <div className="h-full w-full" />
               ) : (
                 <p className="text-sm text-text-secondary">
                   Browse objects in the explorer, or press {shortcutKey}+N for a

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -94,7 +94,7 @@ function App() {
 
       if (!restored) {
         await connectionStore.loadConnections();
-        connectionStore.openDialog();
+        connectionStore.openDialog({ refreshConnections: false });
         return;
       }
 
@@ -143,7 +143,7 @@ function App() {
         useQueryStore.getState().tabs.length === 0 &&
         useConnectionStore.getState().activeConnectionIds.length === 0
       ) {
-        useConnectionStore.getState().openDialog();
+        useConnectionStore.getState().openDialog({ refreshConnections: false });
       }
     };
 
@@ -384,7 +384,7 @@ function App() {
         </button>
 
         <button
-          onClick={openDialog}
+          onClick={() => openDialog()}
           className="rounded bg-accent px-3 py-1 text-sm text-accent-text hover:bg-accent-hover"
         >
           {hasConnections ? "Add Connection" : "Connect"}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -94,9 +94,7 @@ function App() {
 
       if (!restored) {
         await connectionStore.loadConnections();
-        window.requestAnimationFrame(() => {
-          useConnectionStore.getState().openDialog();
-        });
+        connectionStore.openDialog();
         return;
       }
 
@@ -145,9 +143,7 @@ function App() {
         useQueryStore.getState().tabs.length === 0 &&
         useConnectionStore.getState().activeConnectionIds.length === 0
       ) {
-        window.requestAnimationFrame(() => {
-          useConnectionStore.getState().openDialog();
-        });
+        useConnectionStore.getState().openDialog();
       }
     };
 

--- a/src/features/connection/store/connectionStore.ts
+++ b/src/features/connection/store/connectionStore.ts
@@ -38,7 +38,7 @@ interface ConnectionState {
   loadConnections: () => Promise<void>;
   setFormDirty: (dirty: boolean) => void;
   selectConnection: (c: ConnectionInfo | null) => void;
-  openDialog: () => void;
+  openDialog: (options?: { refreshConnections?: boolean }) => void;
   closeDialog: () => void;
   setDialogTab: (tab: DialogTab) => void;
   setSearchFilter: (filter: string) => void;
@@ -89,7 +89,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       formDirty: false,
     })),
 
-  openDialog: () => {
+  openDialog: (options) => {
     set((state) => ({
       dialogOpen: true,
       dialogTab: "properties",
@@ -105,7 +105,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           ? state.activeOperationTarget
           : null,
     }));
-    get().loadConnections();
+    if (options?.refreshConnections !== false) {
+      get().loadConnections();
+    }
   },
 
   closeDialog: () => {


### PR DESCRIPTION
## Summary
- Stop the app from auto-opening Web Inspector unless a debug build explicitly sets `SSMSX_OPEN_DEVTOOLS=1`
- Open the connection dialog on first launch after loading saved connections, and remove the large centered empty-state CTA behind it
- Persist the computed release app version across release workflow steps and fail the release if the built macOS app bundle metadata does not match

## Verification
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `actionlint .github/workflows/ci.yml`