### PR TITLE
Fix deployed build stuck on "Loading..." (self-host Monaco)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@xyflow/react": "^12.10.2",
         "dagre": "^0.8.5",
         "lucide-react": "^1.16.0",
+        "monaco-editor": "^0.55.1",
         "react": "^19",
         "react-dom": "^19",
         "tailwindcss": "^4.2.1",
@@ -1798,8 +1799,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2117,7 +2117,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
       "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2579,7 +2578,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2592,7 +2590,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@xyflow/react": "^12.10.2",
     "dagre": "^0.8.5",
     "lucide-react": "^1.16.0",
+    "monaco-editor": "^0.55.1",
     "react": "^19",
     "react-dom": "^19",
     "tailwindcss": "^4.2.1",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import ReactDOM from "react-dom/client";
+import "./monaco-setup";
 import App from "./app/App";
 import { ErrorBoundary } from "./shared/components/ErrorBoundary";
 import { initQueryEventListeners } from "./features/query";

--- a/src/monaco-setup.ts
+++ b/src/monaco-setup.ts
@@ -7,10 +7,12 @@ import { loader } from "@monaco-editor/react";
 // which blocks the CDN fetch and leaves the editor stuck on "Loading...".
 // Only the base editor worker is needed — we use Monaco for SQL editing with a
 // custom completion provider, not the JSON/TS/CSS language services.
-self.MonacoEnvironment = {
-  getWorker() {
-    return new editorWorker();
-  },
+//
+// monaco-editor declares MonacoEnvironment as an ambient global binding (not a
+// property of Window), so assign it directly rather than via `self` — Monaco
+// reads getWorker from it to locate its web worker.
+MonacoEnvironment = {
+  getWorker: (_workerId: string, _label: string) => new editorWorker(),
 };
 
 loader.config({ monaco });

--- a/src/monaco-setup.ts
+++ b/src/monaco-setup.ts
@@ -1,0 +1,16 @@
+import * as monaco from "monaco-editor";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import { loader } from "@monaco-editor/react";
+
+// Self-host Monaco from the bundle instead of @monaco-editor/react's default
+// CDN loader. The packaged app runs under a strict CSP (script-src 'self'),
+// which blocks the CDN fetch and leaves the editor stuck on "Loading...".
+// Only the base editor worker is needed — we use Monaco for SQL editing with a
+// custom completion provider, not the JSON/TS/CSS language services.
+self.MonacoEnvironment = {
+  getWorker() {
+    return new editorWorker();
+  },
+};
+
+loader.config({ monaco });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src/app", "src/features", "src/shared", "src/main.tsx", "src/vite-env.d.ts"]
+  "include": ["src/app", "src/features", "src/shared", "src/main.tsx", "src/monaco-setup.ts", "src/vite-env.d.ts"]
 }


### PR DESCRIPTION
## Summary

- The released app hung on Monaco's built-in "Loading..." placeholder while local dev was fine. `@monaco-editor/react` loads the Monaco runtime from the jsdelivr CDN by default, and the release CSP (`script-src 'self'`) blocks that fetch, so the editor never initialized. Dev only worked because `tauri.conf.dev.json` sets `csp` to `null`.
- Self-host Monaco from the bundle: a new `src/monaco-setup.ts` wires the local editor worker and points the loader at the bundled `monaco` instance via `loader.config({ monaco })`, so it loads from `'self'` with no network call. `monaco-editor` is now a direct dependency.
- The strict production CSP is unchanged — loosening it to allow the CDN would keep a runtime network dependency and weaken the policy.

## Test plan

- [x] `npm run build` bundles `editor.worker` and the SQL language chunks locally
- [x] Serving the built `dist` loads the app with zero CDN requests
- [x] `cargo tauri build` (strict CSP) succeeds; the new binary embeds `editor.worker` while the currently-deployed binary embeds none
- [ ] Open a query tab in the packaged app and confirm the editor renders with syntax highlighting and SQL autocomplete