### PR TITLE
Fix blank screen on startup from Monaco global assignment

### DIFF
--- a/src/monaco-setup.ts
+++ b/src/monaco-setup.ts
@@ -8,10 +8,11 @@ import { loader } from "@monaco-editor/react";
 // Only the base editor worker is needed — we use Monaco for SQL editing with a
 // custom completion provider, not the JSON/TS/CSS language services.
 //
-// monaco-editor declares MonacoEnvironment as an ambient global binding (not a
-// property of Window), so assign it directly rather than via `self` — Monaco
-// reads getWorker from it to locate its web worker.
-MonacoEnvironment = {
+// monaco-editor's `declare global { var MonacoEnvironment }` is ambient (type-only),
+// so a bare `MonacoEnvironment = …` assignment has no runtime binding and throws
+// ReferenceError under ESM strict mode, crashing app startup. Assign onto the real
+// global object instead — Monaco reads getWorker from it to locate its web worker.
+globalThis.MonacoEnvironment = {
   getWorker: (_workerId: string, _label: string) => new editorWorker(),
 };
 


### PR DESCRIPTION
## Summary

The Monaco self-host setup (#69) assigned `MonacoEnvironment = {…}` as a bare identifier. `monaco-editor` declares that name via `declare global { var … }`, which is ambient (type-only) and creates no runtime binding — so under ESM strict mode the assignment throws `ReferenceError` at module load. That crashed `main.tsx` before React mounted, leaving a blank window. TypeScript type-checked fine, so CI never caught it.

This replaces the bare assignment with `globalThis.MonacoEnvironment = {…}` — a real runtime binding that's still typed by the ambient declaration.

This regressed in v0.1-beta.3, which is broken in the wild.

## Test plan

- `npx tsc --noEmit` — clean
- `npm run build` — clean
- Served the production build and loaded it in a browser: full app shell + Connect dialog render, zero console errors (previously blank screen + `ReferenceError`)