### PR TITLE
Fix Cmd+N tab spawning + add results-grid range selection

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useRef, useState } from "react";
+import { useEffect, useCallback, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { Info } from "lucide-react";
 import {
@@ -40,8 +40,11 @@ function App() {
     disconnect,
   } = useConnectionStore();
 
-  const activeConnections = connections.filter((c) =>
-    activeConnectionIds.includes(c.id)
+  // Memoized so the array identity is stable across renders — an unstable identity
+  // here cascades into createNewTab/useEffect deps and churns dependent effects.
+  const activeConnections = useMemo(
+    () => connections.filter((c) => activeConnectionIds.includes(c.id)),
+    [connections, activeConnectionIds]
   );
   const hasConnections = activeConnections.length > 0;
 
@@ -52,20 +55,40 @@ function App() {
   const startupInitializedRef = useRef(false);
 
   const createNewTab = useCallback(() => {
-    // Use the first active connection as default
-    const defaultConn = activeConnections[0];
-    if (!defaultConn) return;
+    const activeTab = tabs.find((t) => t.id === activeTabId);
+    // Prefer the connection of the tab the user is on; fall back to the first
+    // active connection so a new query opens against something sensible.
+    const sourceConn =
+      connections.find((c) => c.id === activeTab?.connectionId) ?? activeConnections[0];
+    if (!sourceConn) return;
+
+    // Inherit the active tab's database only when it belongs to the same
+    // connection; otherwise use the connection's default so the user doesn't
+    // have to re-pick the database for every new query.
+    const database =
+      activeTab && activeTab.connectionId === sourceConn.id
+        ? activeTab.database
+        : (sourceConn.database ?? "master");
 
     tabCounter++;
     addTab({
       id: crypto.randomUUID(),
       kind: "query",
-      connectionId: defaultConn.id,
-      database: defaultConn.database ?? "master",
+      connectionId: sourceConn.id,
+      database,
       title: `Query ${tabCounter}`,
-      connectionColor: defaultConn.color,
+      connectionColor: sourceConn.color,
     });
-  }, [activeConnections, addTab]);
+  }, [tabs, activeTabId, connections, activeConnections, addTab]);
+
+  // Hold the latest callbacks so the native-menu listeners (registered once on
+  // mount) always invoke the current implementation without re-registering.
+  const createNewTabRef = useRef(createNewTab);
+  const openDialogRef = useRef(openDialog);
+  useEffect(() => {
+    createNewTabRef.current = createNewTab;
+    openDialogRef.current = openDialog;
+  });
 
   const persistQuerySession = useCallback(() => {
     const queryStore = useQueryStore.getState();
@@ -207,10 +230,10 @@ function App() {
 
   // Listen for new tab events from the tab bar's "+" button
   useEffect(() => {
-    const handler = () => createNewTab();
+    const handler = () => createNewTabRef.current();
     window.addEventListener("query:new-tab", handler);
     return () => window.removeEventListener("query:new-tab", handler);
-  }, [createNewTab]);
+  }, []);
 
   useEffect(() => {
     const handler = (event: Event) => {
@@ -236,29 +259,42 @@ function App() {
     return () => window.removeEventListener("diagram:open", handler);
   }, [addTab, connections]);
 
-  // Listen for native menu events from Tauri
+  // Listen for native menu events from Tauri.
+  // Registered ONCE on mount (empty deps); handlers call through refs so they
+  // always run the latest implementation without re-registering. `track` guards
+  // the async listen() race: a listener that resolves after cleanup is removed
+  // immediately instead of leaking — leaked menu:new-query listeners were why
+  // Cmd+N opened several tabs at once.
   useEffect(() => {
     if (!isTauriRuntime()) return;
 
+    let disposed = false;
     const unlisteners: Array<() => void> = [];
+    const track = (unlisten: () => void) => {
+      if (disposed) {
+        unlisten();
+      } else {
+        unlisteners.push(unlisten);
+      }
+    };
 
     const setup = async () => {
       // File > New Query
-      unlisteners.push(
+      track(
         await listen("menu:new-query", () => {
-          createNewTab();
+          createNewTabRef.current();
         })
       );
 
       // File > New Connection
-      unlisteners.push(
+      track(
         await listen("menu:new-connection", () => {
-          openDialog();
+          openDialogRef.current();
         })
       );
 
       // File > Close Tab
-      unlisteners.push(
+      track(
         await listen("menu:close-tab", () => {
           const store = useQueryStore.getState();
           if (store.activeTabId) {
@@ -268,21 +304,21 @@ function App() {
       );
 
       // Query > Execute
-      unlisteners.push(
+      track(
         await listen("menu:execute-query", () => {
           window.dispatchEvent(new CustomEvent("query:execute"));
         })
       );
 
       // Query > Execute Selection
-      unlisteners.push(
+      track(
         await listen("menu:execute-selection", () => {
           window.dispatchEvent(new CustomEvent("query:execute"));
         })
       );
 
       // Query > Cancel
-      unlisteners.push(
+      track(
         await listen("menu:cancel-query", () => {
           const store = useQueryStore.getState();
           if (store.activeTabId) {
@@ -292,14 +328,14 @@ function App() {
       );
 
       // SSMSx > Settings
-      unlisteners.push(
+      track(
         await listen("menu:show-settings", () => {
           setSettingsOpen(true);
         })
       );
 
       // SSMSx > About SSMSx
-      unlisteners.push(
+      track(
         await listen("menu:show-about", () => {
           setAboutOpen(true);
         })
@@ -311,11 +347,12 @@ function App() {
     );
 
     return () => {
+      disposed = true;
       for (const unlisten of unlisteners) {
         unlisten();
       }
     };
-  }, [createNewTab, openDialog]);
+  }, []);
 
   // Global keyboard shortcuts (F5 for execute when editor is not focused)
   useEffect(() => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -56,10 +56,12 @@ function App() {
 
   const createNewTab = useCallback(() => {
     const activeTab = tabs.find((t) => t.id === activeTabId);
-    // Prefer the connection of the tab the user is on; fall back to the first
-    // active connection so a new query opens against something sensible.
+    // Prefer the connection of the tab the user is on, but only if it's still
+    // active — a disconnected connection lingers in `connections`, and binding a
+    // new tab to it would make executeQuery reject the tab. Fall back to the
+    // first active connection so a new query always opens against a live one.
     const sourceConn =
-      connections.find((c) => c.id === activeTab?.connectionId) ?? activeConnections[0];
+      activeConnections.find((c) => c.id === activeTab?.connectionId) ?? activeConnections[0];
     if (!sourceConn) return;
 
     // Inherit the active tab's database only when it belongs to the same
@@ -79,7 +81,7 @@ function App() {
       title: `Query ${tabCounter}`,
       connectionColor: sourceConn.color,
     });
-  }, [tabs, activeTabId, connections, activeConnections, addTab]);
+  }, [tabs, activeTabId, activeConnections, addTab]);
 
   // Hold the latest callbacks so the native-menu listeners (registered once on
   // mount) always invoke the current implementation without re-registering.
@@ -88,7 +90,7 @@ function App() {
   useEffect(() => {
     createNewTabRef.current = createNewTab;
     openDialogRef.current = openDialog;
-  });
+  }, [createNewTab, openDialog]);
 
   const persistQuerySession = useCallback(() => {
     const queryStore = useQueryStore.getState();

--- a/src/features/query/components/QueryResultsTable.tsx
+++ b/src/features/query/components/QueryResultsTable.tsx
@@ -133,7 +133,10 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
     setSelection(null);
     setAllRowsSelected(false);
     setContextMenu(null);
-  }, [activeResultSetIndex, activeTab]);
+    // activeResultSet is included so a fresh query execution (which swaps the
+    // result while index/tab stay the same) clears any stale, now-out-of-bounds
+    // selection instead of leaving it active on the new grid.
+  }, [activeResultSetIndex, activeTab, activeResultSet]);
 
   // End a drag even if the pointer is released outside the grid.
   useEffect(() => {

--- a/src/features/query/components/QueryResultsTable.tsx
+++ b/src/features/query/components/QueryResultsTable.tsx
@@ -21,9 +21,41 @@ const MAX_DISPLAY_ROWS = 1000;
 
 type ActiveTab = "results" | "messages";
 
-interface SelectedCell {
+interface CellRef {
   rowIndex: number;
   colIndex: number;
+}
+
+/**
+ * A rectangular selection defined by two corners. `anchor` is where the
+ * selection started (fixed while extending); `focus` is the moving/active
+ * corner. A single-cell selection is just `anchor === focus`.
+ */
+interface CellRange {
+  anchor: CellRef;
+  focus: CellRef;
+}
+
+interface RangeBounds {
+  minRow: number;
+  maxRow: number;
+  minCol: number;
+  maxCol: number;
+}
+
+function rangeBounds(range: CellRange): RangeBounds {
+  return {
+    minRow: Math.min(range.anchor.rowIndex, range.focus.rowIndex),
+    maxRow: Math.max(range.anchor.rowIndex, range.focus.rowIndex),
+    minCol: Math.min(range.anchor.colIndex, range.focus.colIndex),
+    maxCol: Math.max(range.anchor.colIndex, range.focus.colIndex),
+  };
+}
+
+function isInRange(range: CellRange | null, rowIndex: number, colIndex: number): boolean {
+  if (!range) return false;
+  const { minRow, maxRow, minCol, maxCol } = rangeBounds(range);
+  return rowIndex >= minRow && rowIndex <= maxRow && colIndex >= minCol && colIndex <= maxCol;
 }
 
 interface GridContextMenu {
@@ -58,11 +90,18 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
   const [activeTab, setActiveTab] = useState<ActiveTab>(
     hasData ? "results" : "messages"
   );
-  const [selectedCell, setSelectedCell] = useState<SelectedCell | null>(null);
+  const [selection, setSelection] = useState<CellRange | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
   const [allRowsSelected, setAllRowsSelected] = useState(false);
   const [contextMenu, setContextMenu] = useState<GridContextMenu | null>(null);
   const [copyStatus, setCopyStatus] = useState<string | null>(null);
   const gridRef = useRef<HTMLDivElement>(null);
+  // Read inside the per-cell onMouseEnter handler; a ref avoids re-subscribing
+  // every cell on each drag-state change.
+  const isDraggingRef = useRef(false);
+
+  // The active/focus cell drives keyboard navigation and single-target copies.
+  const focusCell = selection?.focus ?? null;
 
   // If the situation changes (e.g. a new execution that only produced messages),
   // snap the active tab back to whichever has content.
@@ -91,10 +130,20 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
   );
 
   useEffect(() => {
-    setSelectedCell(null);
+    setSelection(null);
     setAllRowsSelected(false);
     setContextMenu(null);
   }, [activeResultSetIndex, activeTab]);
+
+  // End a drag even if the pointer is released outside the grid.
+  useEffect(() => {
+    const stop = () => {
+      isDraggingRef.current = false;
+      setIsDragging(false);
+    };
+    window.addEventListener("mouseup", stop);
+    return () => window.removeEventListener("mouseup", stop);
+  }, []);
 
   useEffect(() => {
     if (!copyStatus) return;
@@ -130,29 +179,66 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
   );
 
   const copySelectedCell = useCallback(() => {
-    if (!activeResultSet || !selectedCell) return;
-    const value = activeResultSet.rows[selectedCell.rowIndex]?.[selectedCell.colIndex];
+    if (!activeResultSet || !focusCell) return;
+    const value = activeResultSet.rows[focusCell.rowIndex]?.[focusCell.colIndex];
     void copyText(formatCell(value), "Copied cell");
-  }, [activeResultSet, copyText, selectedCell]);
+  }, [activeResultSet, copyText, focusCell]);
 
   const copySelectedRow = useCallback(
     (includeHeaders: boolean) => {
-      if (!activeResultSet || !selectedCell) return;
-      const row = activeResultSet.rows[selectedCell.rowIndex];
+      if (!activeResultSet || !focusCell) return;
+      const row = activeResultSet.rows[focusCell.rowIndex];
       if (!row) return;
       const rows = includeHeaders
         ? [activeResultSet.columns.map((column) => column.name), row]
         : [row];
       void copyText(rowsToTsv(rows), includeHeaders ? "Copied row with headers" : "Copied row");
     },
-    [activeResultSet, copyText, selectedCell]
+    [activeResultSet, copyText, focusCell]
   );
 
-  const selectCell = useCallback((rowIndex: number, colIndex: number) => {
-    setSelectedCell({ rowIndex, colIndex });
-    setAllRowsSelected(false);
-    gridRef.current?.focus();
-  }, []);
+  // Copy the rectangular selection as TSV (the Excel/SSMS-friendly format).
+  // A single-cell selection copies just that cell; multi-cell copies the block.
+  const copySelectionRange = useCallback(
+    (includeHeaders: boolean) => {
+      if (!activeResultSet || !selection) return;
+      const { minRow, maxRow, minCol, maxCol } = rangeBounds(selection);
+      const body: unknown[][] = [];
+      for (let r = minRow; r <= maxRow; r++) {
+        const row = activeResultSet.rows[r];
+        if (!row) continue;
+        body.push(row.slice(minCol, maxCol + 1));
+      }
+      const rows = includeHeaders
+        ? [
+            activeResultSet.columns.slice(minCol, maxCol + 1).map((column) => column.name),
+            ...body,
+          ]
+        : body;
+      const single = minRow === maxRow && minCol === maxCol;
+      const status = single
+        ? "Copied cell"
+        : includeHeaders
+          ? "Copied selection with headers"
+          : "Copied selection";
+      void copyText(rowsToTsv(rows), status);
+    },
+    [activeResultSet, copyText, selection]
+  );
+
+  // Begin a selection (or extend it when shift is held).
+  const startSelection = useCallback(
+    (rowIndex: number, colIndex: number, extend: boolean) => {
+      setAllRowsSelected(false);
+      setSelection((prev) =>
+        extend && prev
+          ? { anchor: prev.anchor, focus: { rowIndex, colIndex } }
+          : { anchor: { rowIndex, colIndex }, focus: { rowIndex, colIndex } }
+      );
+      gridRef.current?.focus();
+    },
+    []
+  );
 
   const handleGridKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -162,16 +248,22 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
       const colCount = activeResultSet.columns.length;
       if (rowCount === 0 || colCount === 0) return;
 
-      const currentCell = selectedCell ?? { rowIndex: 0, colIndex: 0 };
-      const moveSelection = (rowDelta: number, colDelta: number) => {
+      const current = focusCell ?? { rowIndex: 0, colIndex: 0 };
+      // Move the focus corner. With shift, keep the anchor (grows the block);
+      // without shift, collapse to a single cell at the new focus.
+      const moveSelection = (rowDelta: number, colDelta: number, toCol?: number) => {
         event.preventDefault();
-        setSelectedCell(
-          selectedCell
-            ? {
-                rowIndex: clampIndex(currentCell.rowIndex + rowDelta, rowCount),
-                colIndex: clampIndex(currentCell.colIndex + colDelta, colCount),
-              }
-            : { rowIndex: 0, colIndex: 0 }
+        const nextFocus: CellRef = {
+          rowIndex: clampIndex(current.rowIndex + rowDelta, rowCount),
+          colIndex:
+            toCol !== undefined
+              ? clampIndex(toCol, colCount)
+              : clampIndex(current.colIndex + colDelta, colCount),
+        };
+        setSelection((prev) =>
+          event.shiftKey && prev
+            ? { anchor: prev.anchor, focus: nextFocus }
+            : { anchor: nextFocus, focus: nextFocus }
         );
         setAllRowsSelected(false);
       };
@@ -179,7 +271,7 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "a") {
         event.preventDefault();
         setAllRowsSelected(true);
-        setSelectedCell(null);
+        setSelection(null);
         return;
       }
 
@@ -187,10 +279,8 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
         event.preventDefault();
         if (allRowsSelected) {
           copyResultSet(event.shiftKey);
-        } else if (event.shiftKey) {
-          copySelectedRow(true);
-        } else {
-          copySelectedCell();
+        } else if (selection) {
+          copySelectionRange(event.shiftKey);
         }
         return;
       }
@@ -204,13 +294,9 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
       } else if (event.key === "ArrowRight") {
         moveSelection(0, 1);
       } else if (event.key === "Home") {
-        event.preventDefault();
-        setSelectedCell({ rowIndex: currentCell.rowIndex, colIndex: 0 });
-        setAllRowsSelected(false);
+        moveSelection(0, 0, 0);
       } else if (event.key === "End") {
-        event.preventDefault();
-        setSelectedCell({ rowIndex: currentCell.rowIndex, colIndex: colCount - 1 });
-        setAllRowsSelected(false);
+        moveSelection(0, 0, colCount - 1);
       }
     },
     [
@@ -218,9 +304,9 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
       activeTab,
       allRowsSelected,
       copyResultSet,
-      copySelectedCell,
-      copySelectedRow,
-      selectedCell,
+      copySelectionRange,
+      focusCell,
+      selection,
       visibleRows.length,
     ]
   );
@@ -228,26 +314,51 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
   const handleCellContextMenu = useCallback(
     (event: ReactMouseEvent, rowIndex: number, colIndex: number) => {
       event.preventDefault();
-      selectCell(rowIndex, colIndex);
+      // Keep an existing multi-cell selection if the right-click lands inside it;
+      // otherwise select the clicked cell so the copy actions act on it.
+      if (!isInRange(selection, rowIndex, colIndex)) {
+        startSelection(rowIndex, colIndex, false);
+      }
       setContextMenu({ x: event.clientX, y: event.clientY });
     },
-    [selectCell]
+    [selection, startSelection]
   );
+
+  const isMultiCellSelection = useMemo(() => {
+    if (!selection) return false;
+    const { minRow, maxRow, minCol, maxCol } = rangeBounds(selection);
+    return minRow !== maxRow || minCol !== maxCol;
+  }, [selection]);
 
   const contextMenuItems: ContextMenuItem[] = useMemo(
     () => [
-      { type: "action", label: "Copy Cell", onClick: copySelectedCell, disabled: !selectedCell },
+      ...(isMultiCellSelection
+        ? [
+            {
+              type: "action" as const,
+              label: "Copy Selection",
+              onClick: () => copySelectionRange(false),
+            },
+            {
+              type: "action" as const,
+              label: "Copy Selection with Headers",
+              onClick: () => copySelectionRange(true),
+            },
+            { type: "separator" as const },
+          ]
+        : []),
+      { type: "action", label: "Copy Cell", onClick: copySelectedCell, disabled: !focusCell },
       {
         type: "action",
         label: "Copy Row",
         onClick: () => copySelectedRow(false),
-        disabled: !selectedCell,
+        disabled: !focusCell,
       },
       {
         type: "action",
         label: "Copy Row with Headers",
         onClick: () => copySelectedRow(true),
-        disabled: !selectedCell,
+        disabled: !focusCell,
       },
       { type: "separator" },
       {
@@ -255,7 +366,7 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
         label: "Select All",
         onClick: () => {
           setAllRowsSelected(true);
-          setSelectedCell(null);
+          setSelection(null);
           gridRef.current?.focus();
         },
       },
@@ -270,7 +381,7 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
         onClick: () => copyResultSet(true),
       },
     ],
-    [copyResultSet, copySelectedCell, copySelectedRow, selectedCell]
+    [copyResultSet, copySelectedCell, copySelectedRow, copySelectionRange, focusCell, isMultiCellSelection]
   );
 
   const scrollEndPadding = <div className="h-6 flex-none" aria-hidden="true" />;
@@ -325,10 +436,10 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
             )}
             <button
               type="button"
-              onClick={copySelectedCell}
-              disabled={!selectedCell}
+              onClick={() => copySelectionRange(false)}
+              disabled={!selection}
               className="flex items-center gap-1 px-2 py-1 text-text-secondary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
-              title="Copy selected cell"
+              title={isMultiCellSelection ? "Copy selected cells" : "Copy selected cell"}
             >
               <Copy size={13} />
               Copy
@@ -358,7 +469,9 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
       {activeTab === "results" && activeResultSet && (
         <div
           ref={gridRef}
-          className="min-h-0 flex-1 overflow-auto focus:outline-none"
+          className={`min-h-0 flex-1 overflow-auto focus:outline-none ${
+            isDragging ? "select-none" : ""
+          }`}
           tabIndex={0}
           role="grid"
           aria-label="Query results"
@@ -385,32 +498,51 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
                   className={`${allRowsSelected ? "bg-accent/10" : "hover:bg-bg-secondary"}`}
                   aria-selected={allRowsSelected}
                 >
-                  {row.map((cell, colIndex) => (
-                    <td
-                      key={colIndex}
-                      role="gridcell"
-                      aria-selected={
-                        allRowsSelected ||
-                        (selectedCell?.rowIndex === rowIndex &&
-                          selectedCell.colIndex === colIndex)
-                      }
-                      tabIndex={-1}
-                      onClick={() => selectCell(rowIndex, colIndex)}
-                      onContextMenu={(event) =>
-                        handleCellContextMenu(event, rowIndex, colIndex)
-                      }
-                      className={`whitespace-nowrap border-b border-r border-bg-tertiary px-2 py-0.5 text-text-primary ${
-                        selectedCell?.rowIndex === rowIndex &&
-                        selectedCell.colIndex === colIndex
-                          ? "bg-accent/20 outline outline-1 -outline-offset-1 outline-accent"
-                          : allRowsSelected
-                            ? "bg-accent/10"
-                            : ""
-                      }`}
-                    >
-                      {formatCell(cell)}
-                    </td>
-                  ))}
+                  {row.map((cell, colIndex) => {
+                    const isFocus =
+                      focusCell?.rowIndex === rowIndex &&
+                      focusCell.colIndex === colIndex;
+                    const inRange = isInRange(selection, rowIndex, colIndex);
+                    return (
+                      <td
+                        key={colIndex}
+                        role="gridcell"
+                        aria-selected={allRowsSelected || inRange}
+                        tabIndex={-1}
+                        onMouseDown={(event) => {
+                          // Left button only; preventDefault stops native text
+                          // selection so the drag paints a clean cell rectangle.
+                          if (event.button !== 0) return;
+                          event.preventDefault();
+                          isDraggingRef.current = true;
+                          setIsDragging(true);
+                          startSelection(rowIndex, colIndex, event.shiftKey);
+                        }}
+                        onMouseEnter={() => {
+                          if (!isDraggingRef.current) return;
+                          setSelection((prev) =>
+                            prev
+                              ? { anchor: prev.anchor, focus: { rowIndex, colIndex } }
+                              : prev
+                          );
+                        }}
+                        onContextMenu={(event) =>
+                          handleCellContextMenu(event, rowIndex, colIndex)
+                        }
+                        className={`whitespace-nowrap border-b border-r border-bg-tertiary px-2 py-0.5 text-text-primary ${
+                          isFocus
+                            ? "bg-accent/20 outline outline-1 -outline-offset-1 outline-accent"
+                            : inRange
+                              ? "bg-accent/20"
+                              : allRowsSelected
+                                ? "bg-accent/10"
+                                : ""
+                        }`}
+                      >
+                        {formatCell(cell)}
+                      </td>
+                    );
+                  })}
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## Summary

- **Cmd+N opened multiple query tabs and lost the database.** The native-menu `menu:new-query` listener leaked because its registering effect re-ran every render and registered listeners via async `listen()` against a synchronous cleanup. `activeConnections` is now memoized, the menu listeners register once on mount through refs with a disposed-guard on the async race, and a new query inherits the active tab's connection **and** database.
- **Results grid now supports rectangular range selection.** Click-and-drag to highlight a block, shift-click to extend, shift+arrows to grow/shrink. Cmd/Ctrl+C copies the rectangle as TSV; Cmd/Ctrl+Shift+C includes headers. Single-cell click, arrow nav, Select All and Copy All are unchanged.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] App launches and renders in `tauri:dev` (no startup crash)
- [ ] Cmd+N opens exactly one tab per press; new tab carries the source tab's connection + database
- [ ] Drag/shift-click/shift+arrows select a cell rectangle; Cmd+C and Cmd+Shift+C paste the expected TSV
- [ ] Single-cell selection, arrow navigation, Select All, Copy All still work