### PR TITLE
Fix query editor clipping the first line

### DIFF
--- a/src/features/query/components/QueryEditor.tsx
+++ b/src/features/query/components/QueryEditor.tsx
@@ -126,6 +126,9 @@ export function QueryEditor({
         insertSpaces: true,
         suggestOnTriggerCharacters: true,
         quickSuggestions: true,
+        // Keep line 1 off the top edge — Monaco renders it flush against the
+        // viewport top and the overflow-hidden wrapper clips the glyph tops.
+        padding: { top: 8 },
       }}
     />
   );


### PR DESCRIPTION
## Summary

- Monaco rendered line 1 flush against the top of its viewport; the `overflow-hidden` editor wrapper in `QueryPanel` clipped the top few pixels of the glyphs, so `SELECT …` on line 1 looked cut off.
- Added `padding: { top: 8 }` to the Monaco options so content starts just below the top edge. `automaticLayout` keeps it correct on resize.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] In a query tab, line 1 is fully visible with breathing room above it — no top clipping, including after dragging the results splitter