### PR TITLE
Allow selecting text in the query Messages output

### DIFF
--- a/src/features/query/components/QueryResultsTable.tsx
+++ b/src/features/query/components/QueryResultsTable.tsx
@@ -571,7 +571,9 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
 
       {/* Messages */}
       {activeTab === "messages" && hasMessages && (
-        <div className="min-h-0 flex-1 overflow-auto p-2">
+        // select-text re-enables text selection (body sets user-select: none),
+        // so message/error text can be selected and copied.
+        <div className="min-h-0 flex-1 overflow-auto select-text p-2">
           {result.messages.map((msg, i) => (
             <div
               key={i}

--- a/src/features/query/components/QueryResultsTable.tsx
+++ b/src/features/query/components/QueryResultsTable.tsx
@@ -569,10 +569,9 @@ export function QueryResultsTable({ result }: QueryResultsTableProps) {
         />
       )}
 
-      {/* Messages */}
+      {/* Messages — select-text re-enables text selection here (body sets
+          user-select: none) so message/error text can be selected and copied. */}
       {activeTab === "messages" && hasMessages && (
-        // select-text re-enables text selection (body sets user-select: none),
-        // so message/error text can be selected and copied.
         <div className="min-h-0 flex-1 overflow-auto select-text p-2">
           {result.messages.map((msg, i) => (
             <div


### PR DESCRIPTION
## Summary

- The app sets `user-select: none` on `body` (desktop chrome feel) and only `input`/`textarea`/`pre` opt back in, so the Messages tab's error/print text couldn't be selected or copied.
- Added `select-text` to the Messages container so its subtree re-enables text selection. The results grid keeps its own cell-selection and copy behaviour.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] Run a query that errors/prints → Messages tab text is selectable and Cmd+C copies it; results grid cell selection unaffected