### PR TITLE
Support GO batches and database context sync

### DIFF
--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -241,15 +241,33 @@ public class QueryExecutor
 
     internal static IEnumerable<string> SplitBatches(string sql)
     {
-        var batches = new List<string>();
         var currentBatch = new StringBuilder();
         var inString = false;
+        var inBracketedIdentifier = false;
+        var inDoubleQuotedIdentifier = false;
         var blockCommentDepth = 0;
 
-        using var reader = new StringReader(sql);
-        while (reader.ReadLine() is { } line)
+        for (var lineStart = 0; lineStart < sql.Length;)
         {
-            var separator = !inString && blockCommentDepth == 0
+            var lineEnd = sql.IndexOfAny(['\r', '\n'], lineStart);
+            var line = lineEnd < 0 ? sql[lineStart..] : sql[lineStart..lineEnd];
+            var newline = "";
+            if (lineEnd < 0)
+            {
+                lineStart = sql.Length;
+            }
+            else if (sql[lineEnd] == '\r' && lineEnd + 1 < sql.Length && sql[lineEnd + 1] == '\n')
+            {
+                newline = "\r\n";
+                lineStart = lineEnd + 2;
+            }
+            else
+            {
+                newline = sql[lineEnd].ToString();
+                lineStart = lineEnd + 1;
+            }
+
+            var separator = !inString && !inBracketedIdentifier && !inDoubleQuotedIdentifier && blockCommentDepth == 0
                 ? BatchSeparator.Match(line)
                 : Match.Empty;
             if (separator.Success)
@@ -259,32 +277,31 @@ public class QueryExecutor
                 if (count.Success && !int.TryParse(count.Value, out repeatCount))
                     throw new InvalidOperationException($"GO repeat count '{count.Value}' exceeds the supported maximum of {int.MaxValue}.");
 
-                AddBatch(batches, currentBatch, repeatCount);
+                var batch = currentBatch.ToString();
+                if (!string.IsNullOrWhiteSpace(batch))
+                {
+                    for (var i = 0; i < repeatCount; i++)
+                        yield return batch;
+                }
+                currentBatch.Clear();
                 continue;
             }
 
-            if (currentBatch.Length > 0)
-                currentBatch.Append('\n');
-            currentBatch.Append(line);
-            TrackSqlState(line, ref inString, ref blockCommentDepth);
+            currentBatch.Append(line).Append(newline);
+            TrackSqlState(line, ref inString, ref inBracketedIdentifier, ref inDoubleQuotedIdentifier, ref blockCommentDepth);
         }
 
-        AddBatch(batches, currentBatch, 1);
-        return batches;
+        var finalBatch = currentBatch.ToString();
+        if (!string.IsNullOrWhiteSpace(finalBatch))
+            yield return finalBatch;
     }
 
-    private static void AddBatch(List<string> batches, StringBuilder batch, int repeatCount)
-    {
-        var sql = batch.ToString();
-        if (!string.IsNullOrWhiteSpace(sql))
-        {
-            for (var i = 0; i < repeatCount; i++)
-                batches.Add(sql);
-        }
-        batch.Clear();
-    }
-
-    private static void TrackSqlState(string line, ref bool inString, ref int blockCommentDepth)
+    private static void TrackSqlState(
+        string line,
+        ref bool inString,
+        ref bool inBracketedIdentifier,
+        ref bool inDoubleQuotedIdentifier,
+        ref int blockCommentDepth)
     {
         for (var i = 0; i < line.Length; i++)
         {
@@ -296,6 +313,28 @@ public class QueryExecutor
                     i++;
                 else
                     inString = false;
+                continue;
+            }
+
+            if (inBracketedIdentifier)
+            {
+                if (line[i] != ']')
+                    continue;
+                if (i + 1 < line.Length && line[i + 1] == ']')
+                    i++;
+                else
+                    inBracketedIdentifier = false;
+                continue;
+            }
+
+            if (inDoubleQuotedIdentifier)
+            {
+                if (line[i] != '"')
+                    continue;
+                if (i + 1 < line.Length && line[i + 1] == '"')
+                    i++;
+                else
+                    inDoubleQuotedIdentifier = false;
                 continue;
             }
 
@@ -324,6 +363,14 @@ public class QueryExecutor
             else if (line[i] == '\'')
             {
                 inString = true;
+            }
+            else if (line[i] == '[')
+            {
+                inBracketedIdentifier = true;
+            }
+            else if (line[i] == '"')
+            {
+                inDoubleQuotedIdentifier = true;
             }
         }
     }

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -94,17 +94,17 @@ public class QueryExecutor
             connection.ChangeDatabase(database);
             stopwatch.Start();
             int resultSetIndex = 0;
+            await using var cmd = new SqlCommand
+            {
+                Connection = connection,
+                CommandTimeout = DefaultCommandTimeoutSeconds
+            };
+            _cancellationManager.SetCommand(queryId, cmd);
 
             foreach (var batchSql in SplitBatches(sql))
             {
                 ct.ThrowIfCancellationRequested();
-
-                await using var cmd = new SqlCommand(batchSql, connection)
-                {
-                    CommandTimeout = DefaultCommandTimeoutSeconds
-                };
-
-                _cancellationManager.SetCommand(queryId, cmd);
+                cmd.CommandText = batchSql;
 
                 await using var reader = await cmd.ExecuteReaderAsync(ct);
 

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -265,7 +265,7 @@ public class QueryExecutor
             }
             else
             {
-                newline = sql[lineEnd].ToString();
+                newline = sql[lineEnd] == '\r' ? "\r" : "\n";
                 lineStart = lineEnd + 1;
             }
 

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -160,7 +160,8 @@ public class QueryExecutor
                         await onBatch(batch);
                     }
 
-                    resultSetIndex++;
+                    if (columns.Count > 0)
+                        resultSetIndex++;
                 }
                 while (await reader.NextResultAsync(ct));
             }
@@ -251,16 +252,19 @@ public class QueryExecutor
             var separator = !inString && blockCommentDepth == 0
                 ? BatchSeparator.Match(line)
                 : Match.Empty;
-            var repeatCount = 1;
-            if (separator.Success &&
-                (!separator.Groups["count"].Success || int.TryParse(separator.Groups["count"].Value, out repeatCount)))
+            if (separator.Success)
             {
+                var count = separator.Groups["count"];
+                var repeatCount = 1;
+                if (count.Success && !int.TryParse(count.Value, out repeatCount))
+                    throw new InvalidOperationException($"GO repeat count '{count.Value}' exceeds the supported maximum of {int.MaxValue}.");
+
                 AddBatch(batches, currentBatch, repeatCount);
                 continue;
             }
 
             if (currentBatch.Length > 0)
-                currentBatch.AppendLine();
+                currentBatch.Append('\n');
             currentBatch.Append(line);
             TrackSqlState(line, ref inString, ref blockCommentDepth);
         }

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -16,7 +16,7 @@ namespace Ssmsx.Core.Query;
 public class QueryExecutor
 {
     private static readonly Regex BatchSeparator = new(
-        @"^[\t ]*GO[\t ]*(?:--[^\r\n]*)?\r?$",
+        @"^[\t ]*GO(?:[\t ]+(?<count>[1-9][0-9]*))?[\t ]*(?:--[^\r\n]*)?\r?$",
         RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);
 
     private readonly ConnectionManager _connectionManager;
@@ -248,9 +248,14 @@ public class QueryExecutor
         using var reader = new StringReader(sql);
         while (reader.ReadLine() is { } line)
         {
-            if (!inString && blockCommentDepth == 0 && BatchSeparator.IsMatch(line))
+            var separator = !inString && blockCommentDepth == 0
+                ? BatchSeparator.Match(line)
+                : Match.Empty;
+            var repeatCount = 1;
+            if (separator.Success &&
+                (!separator.Groups["count"].Success || int.TryParse(separator.Groups["count"].Value, out repeatCount)))
             {
-                AddBatch(batches, currentBatch);
+                AddBatch(batches, currentBatch, repeatCount);
                 continue;
             }
 
@@ -260,14 +265,18 @@ public class QueryExecutor
             TrackSqlState(line, ref inString, ref blockCommentDepth);
         }
 
-        AddBatch(batches, currentBatch);
+        AddBatch(batches, currentBatch, 1);
         return batches;
     }
 
-    private static void AddBatch(List<string> batches, StringBuilder batch)
+    private static void AddBatch(List<string> batches, StringBuilder batch, int repeatCount)
     {
-        if (!string.IsNullOrWhiteSpace(batch.ToString()))
-            batches.Add(batch.ToString());
+        var sql = batch.ToString();
+        if (!string.IsNullOrWhiteSpace(sql))
+        {
+            for (var i = 0; i < repeatCount; i++)
+                batches.Add(sql);
+        }
         batch.Clear();
     }
 

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -1,5 +1,6 @@
 using System.Data.SqlTypes;
 using System.Diagnostics;
+using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Data.SqlClient;
 using Ssmsx.Core.Connections;
@@ -237,9 +238,82 @@ public class QueryExecutor
         }
     }
 
-    // ponytail: Line-based parsing covers normal scripts; use a T-SQL lexer if multiline literals need GO-only lines.
-    internal static IEnumerable<string> SplitBatches(string sql) =>
-        BatchSeparator.Split(sql).Where(batch => !string.IsNullOrWhiteSpace(batch));
+    internal static IEnumerable<string> SplitBatches(string sql)
+    {
+        var batches = new List<string>();
+        var currentBatch = new StringBuilder();
+        var inString = false;
+        var blockCommentDepth = 0;
+
+        using var reader = new StringReader(sql);
+        while (reader.ReadLine() is { } line)
+        {
+            if (!inString && blockCommentDepth == 0 && BatchSeparator.IsMatch(line))
+            {
+                AddBatch(batches, currentBatch);
+                continue;
+            }
+
+            if (currentBatch.Length > 0)
+                currentBatch.AppendLine();
+            currentBatch.Append(line);
+            TrackSqlState(line, ref inString, ref blockCommentDepth);
+        }
+
+        AddBatch(batches, currentBatch);
+        return batches;
+    }
+
+    private static void AddBatch(List<string> batches, StringBuilder batch)
+    {
+        if (!string.IsNullOrWhiteSpace(batch.ToString()))
+            batches.Add(batch.ToString());
+        batch.Clear();
+    }
+
+    private static void TrackSqlState(string line, ref bool inString, ref int blockCommentDepth)
+    {
+        for (var i = 0; i < line.Length; i++)
+        {
+            if (inString)
+            {
+                if (line[i] != '\'')
+                    continue;
+                if (i + 1 < line.Length && line[i + 1] == '\'')
+                    i++;
+                else
+                    inString = false;
+                continue;
+            }
+
+            if (blockCommentDepth > 0)
+            {
+                if (i + 1 < line.Length && line[i] == '/' && line[i + 1] == '*')
+                {
+                    blockCommentDepth++;
+                    i++;
+                }
+                else if (i + 1 < line.Length && line[i] == '*' && line[i + 1] == '/')
+                {
+                    blockCommentDepth--;
+                    i++;
+                }
+                continue;
+            }
+
+            if (i + 1 < line.Length && line[i] == '-' && line[i + 1] == '-')
+                return;
+            if (i + 1 < line.Length && line[i] == '/' && line[i + 1] == '*')
+            {
+                blockCommentDepth++;
+                i++;
+            }
+            else if (line[i] == '\'')
+            {
+                inString = true;
+            }
+        }
+    }
 
     /// <summary>
     /// Reads column metadata from the current result set of a SqlDataReader.

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -1,5 +1,6 @@
 using System.Data.SqlTypes;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Microsoft.Data.SqlClient;
 using Ssmsx.Core.Connections;
 using Ssmsx.Protocol.Messages;
@@ -13,6 +14,10 @@ namespace Ssmsx.Core.Query;
 /// </summary>
 public class QueryExecutor
 {
+    private static readonly Regex BatchSeparator = new(
+        @"^[\t ]*GO[\t ]*(?:--[^\r\n]*)?\r?$",
+        RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);
+
     private readonly ConnectionManager _connectionManager;
     private readonly QueryCancellationManager _cancellationManager;
 
@@ -86,73 +91,74 @@ public class QueryExecutor
         try
         {
             connection.ChangeDatabase(database);
-
-            await using var cmd = new SqlCommand(sql, connection)
-            {
-                CommandTimeout = DefaultCommandTimeoutSeconds
-            };
-
-            _cancellationManager.SetCommand(queryId, cmd);
-
             stopwatch.Start();
-
-            await using var reader = await cmd.ExecuteReaderAsync(ct);
-
             int resultSetIndex = 0;
 
-            do
+            foreach (var batchSql in SplitBatches(sql))
             {
-                // Read column metadata for this result set
-                var columns = ReadColumnMetadata(reader);
-                bool isFirstBatchForResultSet = true;
-
-                var rowBuffer = new List<List<object?>>();
-
-                while (await reader.ReadAsync(ct))
+                await using var cmd = new SqlCommand(batchSql, connection)
                 {
-                    var row = ReadRow(reader);
-                    rowBuffer.Add(row);
-                    totalRows++;
+                    CommandTimeout = DefaultCommandTimeoutSeconds
+                };
 
-                    if (rowBuffer.Count >= BatchSize)
+                _cancellationManager.SetCommand(queryId, cmd);
+
+                await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+                do
+                {
+                    // Read column metadata for this result set
+                    var columns = ReadColumnMetadata(reader);
+                    bool isFirstBatchForResultSet = true;
+
+                    var rowBuffer = new List<List<object?>>();
+
+                    while (await reader.ReadAsync(ct))
+                    {
+                        var row = ReadRow(reader);
+                        rowBuffer.Add(row);
+                        totalRows++;
+
+                        if (rowBuffer.Count >= BatchSize)
+                        {
+                            batchNumber++;
+                            var batch = new QueryExecuteResult
+                            {
+                                QueryId = queryId,
+                                Columns = isFirstBatchForResultSet ? columns : null,
+                                Rows = rowBuffer,
+                                Batch = batchNumber,
+                                Done = false,
+                                ResultSetIndex = resultSetIndex
+                            };
+
+                            await onBatch(batch);
+                            rowBuffer = new List<List<object?>>();
+                            isFirstBatchForResultSet = false;
+                        }
+                    }
+
+                    // Send remaining rows for this result set (or an empty batch with columns if no rows)
+                    if (rowBuffer.Count > 0 || isFirstBatchForResultSet)
                     {
                         batchNumber++;
                         var batch = new QueryExecuteResult
                         {
                             QueryId = queryId,
                             Columns = isFirstBatchForResultSet ? columns : null,
-                            Rows = rowBuffer,
+                            Rows = rowBuffer.Count > 0 ? rowBuffer : null,
                             Batch = batchNumber,
                             Done = false,
                             ResultSetIndex = resultSetIndex
                         };
 
                         await onBatch(batch);
-                        rowBuffer = new List<List<object?>>();
-                        isFirstBatchForResultSet = false;
                     }
+
+                    resultSetIndex++;
                 }
-
-                // Send remaining rows for this result set (or an empty batch with columns if no rows)
-                if (rowBuffer.Count > 0 || isFirstBatchForResultSet)
-                {
-                    batchNumber++;
-                    var batch = new QueryExecuteResult
-                    {
-                        QueryId = queryId,
-                        Columns = isFirstBatchForResultSet ? columns : null,
-                        Rows = rowBuffer.Count > 0 ? rowBuffer : null,
-                        Batch = batchNumber,
-                        Done = false,
-                        ResultSetIndex = resultSetIndex
-                    };
-
-                    await onBatch(batch);
-                }
-
-                resultSetIndex++;
+                while (await reader.NextResultAsync(ct));
             }
-            while (await reader.NextResultAsync(ct));
 
             stopwatch.Stop();
 
@@ -165,7 +171,8 @@ public class QueryExecutor
                 Done = true,
                 ExecutionTimeMs = stopwatch.ElapsedMilliseconds,
                 TotalRows = totalRows,
-                Messages = messages.Count > 0 ? messages : null
+                Messages = messages.Count > 0 ? messages : null,
+                Database = connection.Database
             };
 
             await onBatch(finalBatch);
@@ -188,7 +195,8 @@ public class QueryExecutor
                 Done = true,
                 ExecutionTimeMs = stopwatch.ElapsedMilliseconds,
                 TotalRows = totalRows,
-                Messages = messages.Count > 0 ? messages : null
+                Messages = messages.Count > 0 ? messages : null,
+                Database = connection.Database
             };
 
             await onBatch(cancelledBatch);
@@ -212,7 +220,8 @@ public class QueryExecutor
                 Done = true,
                 ExecutionTimeMs = stopwatch.ElapsedMilliseconds,
                 TotalRows = totalRows,
-                Messages = messages.Count > 0 ? messages : null
+                Messages = messages.Count > 0 ? messages : null,
+                Database = connection.Database
             };
 
             await onBatch(cancelledBatch);
@@ -223,6 +232,9 @@ public class QueryExecutor
             _cancellationManager.Remove(queryId);
         }
     }
+
+    internal static IEnumerable<string> SplitBatches(string sql) =>
+        BatchSeparator.Split(sql).Where(batch => !string.IsNullOrWhiteSpace(batch));
 
     /// <summary>
     /// Reads column metadata from the current result set of a SqlDataReader.

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -16,7 +16,7 @@ namespace Ssmsx.Core.Query;
 public class QueryExecutor
 {
     private static readonly Regex BatchSeparator = new(
-        @"^[\t ]*GO(?:[\t ]+(?<count>[1-9][0-9]*))?[\t ]*(?:--[^\r\n]*)?\r?$",
+        @"^[\t ]*GO(?:[\t ]+(?<count>[1-9][0-9]*))?[\t ]*(?:/\*(?:[^*]|\*(?!/))*\*/[\t ]*)*(?:--[^\r\n]*)?\r?$",
         RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);
 
     private readonly ConnectionManager _connectionManager;

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -96,6 +96,8 @@ public class QueryExecutor
 
             foreach (var batchSql in SplitBatches(sql))
             {
+                ct.ThrowIfCancellationRequested();
+
                 await using var cmd = new SqlCommand(batchSql, connection)
                 {
                     CommandTimeout = DefaultCommandTimeoutSeconds
@@ -129,7 +131,8 @@ public class QueryExecutor
                                 Rows = rowBuffer,
                                 Batch = batchNumber,
                                 Done = false,
-                                ResultSetIndex = resultSetIndex
+                                ResultSetIndex = resultSetIndex,
+                                Database = connection.Database
                             };
 
                             await onBatch(batch);
@@ -149,7 +152,8 @@ public class QueryExecutor
                             Rows = rowBuffer.Count > 0 ? rowBuffer : null,
                             Batch = batchNumber,
                             Done = false,
-                            ResultSetIndex = resultSetIndex
+                            ResultSetIndex = resultSetIndex,
+                            Database = connection.Database
                         };
 
                         await onBatch(batch);
@@ -233,6 +237,7 @@ public class QueryExecutor
         }
     }
 
+    // ponytail: Line-based parsing covers normal scripts; use a T-SQL lexer if multiline literals need GO-only lines.
     internal static IEnumerable<string> SplitBatches(string sql) =>
         BatchSeparator.Split(sql).Where(batch => !string.IsNullOrWhiteSpace(batch));
 

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -15,6 +15,8 @@ namespace Ssmsx.Core.Query;
 /// </summary>
 public class QueryExecutor
 {
+    private static readonly char[] NewlineCharacters = ['\r', '\n'];
+
     private static readonly Regex BatchSeparator = new(
         @"^[\t ]*GO(?:[\t ]+(?<count>[1-9][0-9]*))?[\t ]*(?:/\*(?:[^*]|\*(?!/))*\*/[\t ]*)*(?:--[^\r\n]*)?\r?$",
         RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);
@@ -249,7 +251,7 @@ public class QueryExecutor
 
         for (var lineStart = 0; lineStart < sql.Length;)
         {
-            var lineEnd = sql.IndexOfAny(['\r', '\n'], lineStart);
+            var lineEnd = sql.IndexOfAny(NewlineCharacters, lineStart);
             var line = lineEnd < 0 ? sql[lineStart..] : sql[lineStart..lineEnd];
             var newline = "";
             if (lineEnd < 0)

--- a/sidecar/src/Ssmsx.Protocol/Messages/QueryMessages.cs
+++ b/sidecar/src/Ssmsx.Protocol/Messages/QueryMessages.cs
@@ -49,6 +49,9 @@ public record QueryExecuteResult
 
     [JsonPropertyName("resultSetIndex")]
     public int? ResultSetIndex { get; init; }
+
+    [JsonPropertyName("database")]
+    public string? Database { get; init; }
 }
 
 public record QueryCancelResult

--- a/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
+++ b/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
@@ -10,7 +10,9 @@ public class QueryExecutorTests
     {
         const string sql = "SELECT '\nGO\n' AS Value\nGO\n/*\nGO\n*/\nSELECT 2\n go -- next batch\nSELECT 3\nGO 2";
 
-        var batches = QueryExecutor.SplitBatches(sql).Select(batch => batch.Trim()).ToArray();
+        var batches = QueryExecutor.SplitBatches(sql)
+            .Select(batch => batch.Trim().ReplaceLineEndings("\n"))
+            .ToArray();
 
         Assert.Equal(["SELECT '\nGO\n' AS Value", "/*\nGO\n*/\nSELECT 2", "SELECT 3", "SELECT 3"], batches);
     }

--- a/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
+++ b/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
@@ -8,10 +8,10 @@ public class QueryExecutorTests
     [Fact]
     public void SplitBatches_RecognizesStandaloneCaseInsensitiveSeparators()
     {
-        const string sql = "SELECT '\nGO\n' AS Value\nGO\n/*\nGO\n*/\nSELECT 2\n go -- next batch\nSELECT 3";
+        const string sql = "SELECT '\nGO\n' AS Value\nGO\n/*\nGO\n*/\nSELECT 2\n go -- next batch\nSELECT 3\nGO 2";
 
         var batches = QueryExecutor.SplitBatches(sql).Select(batch => batch.Trim()).ToArray();
 
-        Assert.Equal(["SELECT '\nGO\n' AS Value", "/*\nGO\n*/\nSELECT 2", "SELECT 3"], batches);
+        Assert.Equal(["SELECT '\nGO\n' AS Value", "/*\nGO\n*/\nSELECT 2", "SELECT 3", "SELECT 3"], batches);
     }
 }

--- a/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
+++ b/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
@@ -24,7 +24,19 @@ public class QueryExecutorTests
 
         var batches = QueryExecutor.SplitBatches(sql).ToArray();
 
-        Assert.Equal(["SELECT 'first\nsecond'", "SELECT 2"], batches);
+        Assert.Equal(["SELECT 'first\nsecond'\n", "SELECT 2"], batches);
+    }
+
+    [Fact]
+    public void SplitBatches_PreservesCrLfAndIgnoresQuotesInsideIdentifiers()
+    {
+        const string sql = "SELECT 1 AS [Owner's Value]\r\nGO\r\nSELECT \"Owner's Value\"\r\nGO\r\nSELECT 'first\r\nsecond'";
+
+        var batches = QueryExecutor.SplitBatches(sql).ToArray();
+
+        Assert.Equal(
+            ["SELECT 1 AS [Owner's Value]\r\n", "SELECT \"Owner's Value\"\r\n", "SELECT 'first\r\nsecond'"],
+            batches);
     }
 
     [Fact]
@@ -35,5 +47,15 @@ public class QueryExecutorTests
         var exception = Assert.Throws<InvalidOperationException>(() => QueryExecutor.SplitBatches(sql).ToArray());
 
         Assert.Contains("exceeds the supported maximum", exception.Message);
+    }
+
+    [Fact]
+    public void SplitBatches_StreamsRepeatedBatches()
+    {
+        const string sql = "SELECT 1\nGO 100000000";
+
+        var batches = QueryExecutor.SplitBatches(sql).Take(2).ToArray();
+
+        Assert.Equal(["SELECT 1\n", "SELECT 1\n"], batches);
     }
 }

--- a/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
+++ b/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
@@ -1,0 +1,17 @@
+using Ssmsx.Core.Query;
+using Xunit;
+
+namespace Ssmsx.Core.Tests.Query;
+
+public class QueryExecutorTests
+{
+    [Fact]
+    public void SplitBatches_RecognizesStandaloneCaseInsensitiveSeparators()
+    {
+        const string sql = "SELECT 1\nGO\nSELECT 'GO'\n go -- next batch\nSELECT 3";
+
+        var batches = QueryExecutor.SplitBatches(sql).Select(batch => batch.Trim()).ToArray();
+
+        Assert.Equal(["SELECT 1", "SELECT 'GO'", "SELECT 3"], batches);
+    }
+}

--- a/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
+++ b/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
@@ -8,7 +8,7 @@ public class QueryExecutorTests
     [Fact]
     public void SplitBatches_RecognizesStandaloneCaseInsensitiveSeparators()
     {
-        const string sql = "SELECT '\nGO\n' AS Value\nGO\n/*\nGO\n*/\nSELECT 2\n go -- next batch\nSELECT 3\nGO 2";
+        const string sql = "SELECT '\nGO\n' AS Value\nGO\n/*\nGO\n*/\nSELECT 2\n go /* end batch */ -- next batch\nSELECT 3\nGO 2";
 
         var batches = QueryExecutor.SplitBatches(sql)
             .Select(batch => batch.Trim().ReplaceLineEndings("\n"))

--- a/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
+++ b/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
@@ -8,10 +8,10 @@ public class QueryExecutorTests
     [Fact]
     public void SplitBatches_RecognizesStandaloneCaseInsensitiveSeparators()
     {
-        const string sql = "SELECT 1\nGO\nSELECT 'GO'\n go -- next batch\nSELECT 3";
+        const string sql = "SELECT '\nGO\n' AS Value\nGO\n/*\nGO\n*/\nSELECT 2\n go -- next batch\nSELECT 3";
 
         var batches = QueryExecutor.SplitBatches(sql).Select(batch => batch.Trim()).ToArray();
 
-        Assert.Equal(["SELECT 1", "SELECT 'GO'", "SELECT 3"], batches);
+        Assert.Equal(["SELECT '\nGO\n' AS Value", "/*\nGO\n*/\nSELECT 2", "SELECT 3"], batches);
     }
 }

--- a/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
+++ b/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
@@ -16,4 +16,24 @@ public class QueryExecutorTests
 
         Assert.Equal(["SELECT '\nGO\n' AS Value", "/*\nGO\n*/\nSELECT 2", "SELECT 3", "SELECT 3"], batches);
     }
+
+    [Fact]
+    public void SplitBatches_PreservesLineFeeds()
+    {
+        const string sql = "SELECT 'first\nsecond'\nGO\nSELECT 2";
+
+        var batches = QueryExecutor.SplitBatches(sql).ToArray();
+
+        Assert.Equal(["SELECT 'first\nsecond'", "SELECT 2"], batches);
+    }
+
+    [Fact]
+    public void SplitBatches_RejectsRepeatCountsAboveIntMaxValue()
+    {
+        const string sql = "SELECT 1\nGO 2147483648";
+
+        var exception = Assert.Throws<InvalidOperationException>(() => QueryExecutor.SplitBatches(sql).ToArray());
+
+        Assert.Contains("exceeds the supported maximum", exception.Message);
+    }
 }

--- a/src/features/query/store/queryStore.ts
+++ b/src/features/query/store/queryStore.ts
@@ -524,6 +524,7 @@ export const useQueryStore = create<QueryState>((set, get) => ({
   handleResultsBatch: (payload) => {
     const tabId = findTabByIds(get().executionInfo, payload.queryId, payload.requestId);
     if (!tabId) return;
+    const database = payload.database;
 
     set((s) => {
       const existing = s.results[tabId] ?? emptyResult();
@@ -545,6 +546,10 @@ export const useQueryStore = create<QueryState>((set, get) => ({
       ];
 
       return {
+        tabs:
+          database && s.tabs.some((tab) => tab.id === tabId && tab.database !== database)
+            ? s.tabs.map((tab) => (tab.id === tabId ? { ...tab, database } : tab))
+            : s.tabs,
         executionInfo: {
           ...s.executionInfo,
           [tabId]: {
@@ -598,9 +603,10 @@ export const useQueryStore = create<QueryState>((set, get) => ({
       );
 
       return {
-        tabs: database
-          ? s.tabs.map((tab) => (tab.id === tabId ? { ...tab, database } : tab))
-          : s.tabs,
+        tabs:
+          database && s.tabs.some((tab) => tab.id === tabId && tab.database !== database)
+            ? s.tabs.map((tab) => (tab.id === tabId ? { ...tab, database } : tab))
+            : s.tabs,
         executionInfo: {
           ...s.executionInfo,
           [tabId]: {

--- a/src/features/query/store/queryStore.ts
+++ b/src/features/query/store/queryStore.ts
@@ -23,6 +23,8 @@ interface TabExecutionInfo {
   queryId: string | null;
   requestId: string | null;
   startTime: number | null;
+  databaseContext?: string;
+  databaseSyncEnabled?: boolean;
 }
 
 interface SavedQuerySession {
@@ -469,6 +471,8 @@ export const useQueryStore = create<QueryState>((set, get) => ({
           queryId: requestId,
           requestId,
           startTime: Date.now(),
+          databaseContext: tab.database,
+          databaseSyncEnabled: true,
         },
       },
       results: {
@@ -528,6 +532,17 @@ export const useQueryStore = create<QueryState>((set, get) => ({
 
     set((s) => {
       const existing = s.results[tabId] ?? emptyResult();
+      const execution = s.executionInfo[tabId];
+      const currentTab = s.tabs.find((tab) => tab.id === tabId);
+      const databaseSyncEnabled =
+        execution?.databaseSyncEnabled !== false &&
+        currentTab?.database === execution?.databaseContext;
+      const tabs =
+        database &&
+        databaseSyncEnabled &&
+        currentTab?.database !== database
+          ? s.tabs.map((tab) => (tab.id === tabId ? { ...tab, database } : tab))
+          : s.tabs;
       const hasResultData =
         (payload.columns && payload.columns.length > 0) ||
         (payload.rows && payload.rows.length > 0);
@@ -546,15 +561,14 @@ export const useQueryStore = create<QueryState>((set, get) => ({
       ];
 
       return {
-        tabs:
-          database && s.tabs.some((tab) => tab.id === tabId && tab.database !== database)
-            ? s.tabs.map((tab) => (tab.id === tabId ? { ...tab, database } : tab))
-            : s.tabs,
+        tabs,
         executionInfo: {
           ...s.executionInfo,
           [tabId]: {
             ...s.executionInfo[tabId],
             queryId: payload.queryId,
+            databaseContext: database ?? execution?.databaseContext,
+            databaseSyncEnabled,
           },
         },
         results: {
@@ -579,6 +593,17 @@ export const useQueryStore = create<QueryState>((set, get) => ({
 
     set((s) => {
       const existing = s.results[tabId] ?? emptyResult();
+      const execution = s.executionInfo[tabId];
+      const currentTab = s.tabs.find((tab) => tab.id === tabId);
+      const databaseSyncEnabled =
+        execution?.databaseSyncEnabled !== false &&
+        currentTab?.database === execution?.databaseContext;
+      const tabs =
+        database &&
+        databaseSyncEnabled &&
+        currentTab?.database !== database
+          ? s.tabs.map((tab) => (tab.id === tabId ? { ...tab, database } : tab))
+          : s.tabs;
       const hasResultData =
         (payload.columns && payload.columns.length > 0) ||
         (payload.rows && payload.rows.length > 0);
@@ -603,16 +628,15 @@ export const useQueryStore = create<QueryState>((set, get) => ({
       );
 
       return {
-        tabs:
-          database && s.tabs.some((tab) => tab.id === tabId && tab.database !== database)
-            ? s.tabs.map((tab) => (tab.id === tabId ? { ...tab, database } : tab))
-            : s.tabs,
+        tabs,
         executionInfo: {
           ...s.executionInfo,
           [tabId]: {
             ...s.executionInfo[tabId],
             state: isCancelled ? "cancelled" : "completed",
             startTime: null,
+            databaseContext: database ?? execution?.databaseContext,
+            databaseSyncEnabled,
           },
         },
         results: {

--- a/src/features/query/store/queryStore.ts
+++ b/src/features/query/store/queryStore.ts
@@ -237,11 +237,21 @@ export const useQueryStore = create<QueryState>((set, get) => ({
   setActiveTab: (id) => set({ activeTabId: id }),
 
   updateTab: (tabId, patch) =>
-    set((state) => ({
-      tabs: state.tabs.map((tab) =>
-        tab.id === tabId ? { ...tab, ...patch } : tab
-      ),
-    })),
+    set((state) => {
+      const execution = state.executionInfo[tabId];
+      return {
+        tabs: state.tabs.map((tab) =>
+          tab.id === tabId ? { ...tab, ...patch } : tab
+        ),
+        executionInfo:
+          patch.database !== undefined && execution?.state === "executing"
+            ? {
+                ...state.executionInfo,
+                [tabId]: { ...execution, databaseSyncEnabled: false },
+              }
+            : state.executionInfo,
+      };
+    }),
 
   updateSql: (tabId, sql) =>
     set((state) => ({

--- a/src/features/query/store/queryStore.ts
+++ b/src/features/query/store/queryStore.ts
@@ -570,6 +570,7 @@ export const useQueryStore = create<QueryState>((set, get) => ({
   handleQueryComplete: (payload) => {
     const tabId = findTabByIds(get().executionInfo, payload.queryId, payload.requestId);
     if (!tabId) return;
+    const database = payload.database;
 
     set((s) => {
       const existing = s.results[tabId] ?? emptyResult();
@@ -597,6 +598,9 @@ export const useQueryStore = create<QueryState>((set, get) => ({
       );
 
       return {
+        tabs: database
+          ? s.tabs.map((tab) => (tab.id === tabId ? { ...tab, database } : tab))
+          : s.tabs,
         executionInfo: {
           ...s.executionInfo,
           [tabId]: {

--- a/src/features/query/types.ts
+++ b/src/features/query/types.ts
@@ -51,6 +51,7 @@ export interface QueryBatchPayload {
   totalRows?: number;
   messages?: QueryMessage[];
   resultSetIndex?: number;
+  database?: string;
 }
 
 /** Payload for query:error events */


### PR DESCRIPTION
## Summary

- Execute standalone `GO` separators as sequential SQL batches on the same connection.
- Return the final database context and keep the query tab selector in sync after `USE`.
- Cover case-insensitive batch separators without treating `GO` inside SQL text as a separator.

## Why

The editor sent the complete script to SQL Server as one command, even though `GO` is a client-side separator. A successful `USE` changed the connection context but left the database selector stale.

## User impact

Multi-batch scripts now run as expected, and the selected database follows successful context changes.

## Validation

- `dotnet test sidecar/Ssmsx.Sidecar.slnx`
- `dotnet format sidecar/Ssmsx.Sidecar.slnx --verify-no-changes --no-restore`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQL scripts can now execute as multiple batches separated by standalone `GO` statements.
  * Query execution results now include database context, and it’s persisted in the corresponding query tab during streaming.
* **Bug Fixes**
  * `GO` is recognized only as a standalone, case-insensitive separator, while being ignored inside string literals and block comments.
  * Multi-batch execution and per-batch cancellation now return consistent final results including database context.
* **Tests**
  * Expanded `GO` splitting coverage (preserves line feeds, rejects unsupported repeat counts above `Int32.MaxValue`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->