### PR TITLE
Sign and notarize the final macOS DMG

### DIFF
--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -111,9 +111,9 @@ Create a stable or beta GitHub release for `SSMSx` with the versioning and relea
    - Build the .NET sidecar for macOS arm64
    - Build the Tauri app bundle
    - Sign with Developer ID
-   - Notarize with Apple
-   - Staple the notarization ticket
-   - Create `ssmsx-{version}-aarch64.dmg`
+   - Create and sign `ssmsx-{version}-aarch64.dmg`
+   - Notarize the DMG with Apple
+   - Staple and validate the notarization ticket
    - Upload the DMG to the release
    - Update `GordonBeeming/homebrew-tap` at `Casks/ssmsx.rb`
 

--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -111,7 +111,8 @@ Create a stable or beta GitHub release for `SSMSx` with the versioning and relea
    - Build the .NET sidecar for macOS arm64
    - Build the Tauri app bundle
    - Sign with Developer ID
-   - Create and sign `ssmsx-{version}-aarch64.dmg`
+   - Notarize and staple the app bundle
+   - Create and sign `ssmsx-{tag without v}-aarch64.dmg`
    - Notarize the DMG with Apple
    - Staple and validate the notarization ticket
    - Upload the DMG to the release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,28 @@ jobs:
             "${APP_BUNDLE}"
           codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}"
 
+      - name: Notarize application
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        run: |
+          test -n "${APPLE_ID}" || { echo "APPLE_ID is not set in the prod environment." >&2; exit 1; }
+          test -n "${APPLE_TEAM_ID}" || { echo "APPLE_TEAM_ID is not set in the prod environment." >&2; exit 1; }
+          test -n "${APPLE_APP_PASSWORD}" || { echo "APPLE_APP_PASSWORD is not set in the prod environment." >&2; exit 1; }
+
+          APP_BUNDLE="src-tauri/target/release/bundle/macos/SSMSx.app"
+          NOTARY_ZIP="${RUNNER_TEMP}/ssmsx-notarize.zip"
+          ditto -c -k --keepParent "${APP_BUNDLE}" "${NOTARY_ZIP}"
+          xcrun notarytool submit "${NOTARY_ZIP}" \
+            --apple-id "${APPLE_ID}" \
+            --team-id "${APPLE_TEAM_ID}" \
+            --password "${APPLE_APP_PASSWORD}" \
+            --wait
+
+      - name: Staple application notarization ticket
+        run: xcrun stapler staple src-tauri/target/release/bundle/macos/SSMSx.app
+
       - name: Create, sign, notarize, and validate DMG
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
             "${APP_BUNDLE}"
           codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}"
 
-      - name: Notarize application
+      - name: Create, sign, notarize, and validate DMG
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -353,28 +353,29 @@ jobs:
           test -n "${APPLE_TEAM_ID}" || { echo "APPLE_TEAM_ID is not set in the prod environment." >&2; exit 1; }
           test -n "${APPLE_APP_PASSWORD}" || { echo "APPLE_APP_PASSWORD is not set in the prod environment." >&2; exit 1; }
 
-          APP_BUNDLE="src-tauri/target/release/bundle/macos/SSMSx.app"
-          NOTARY_ZIP="${RUNNER_TEMP}/ssmsx-notarize.zip"
-          ditto -c -k --keepParent "${APP_BUNDLE}" "${NOTARY_ZIP}"
-          xcrun notarytool submit "${NOTARY_ZIP}" \
-            --apple-id "${APPLE_ID}" \
-            --team-id "${APPLE_TEAM_ID}" \
-            --password "${APPLE_APP_PASSWORD}" \
-            --wait
-
-      - name: Staple notarization ticket
-        run: xcrun stapler staple src-tauri/target/release/bundle/macos/SSMSx.app
-
-      - name: Create DMG
-        run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          DMG="dist/release/ssmsx-${VERSION}-aarch64.dmg"
           mkdir -p dist/release
           hdiutil create \
             -volname "SSMSx" \
             -srcfolder src-tauri/target/release/bundle/macos/SSMSx.app \
             -ov \
             -format UDZO \
-            "dist/release/ssmsx-${VERSION}-aarch64.dmg"
+            "${DMG}"
+          codesign --force \
+            --timestamp \
+            --sign "Developer ID Application: Gordon Beeming (89DBN36T4T)" \
+            "${DMG}"
+          codesign --verify --verbose=2 "${DMG}"
+          xcrun notarytool submit "${DMG}" \
+            --apple-id "${APPLE_ID}" \
+            --team-id "${APPLE_TEAM_ID}" \
+            --password "${APPLE_APP_PASSWORD}" \
+            --wait
+          xcrun stapler staple "${DMG}"
+          xcrun stapler validate "${DMG}"
+          hdiutil verify "${DMG}"
+          spctl -a -t open --context context:primary-signature -vv "${DMG}"
 
       - name: Upload release asset
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,8 @@ jobs:
     environment: prod
     permissions:
       contents: write
+    env:
+      APPLE_SIGNING_IDENTITY: "Developer ID Application: Gordon Beeming (89DBN36T4T)"
 
     steps:
       - name: Checkout repository
@@ -316,8 +318,6 @@ jobs:
           rm certificate.p12
 
       - name: Build signed app bundle
-        env:
-          APPLE_SIGNING_IDENTITY: "Developer ID Application: Gordon Beeming (89DBN36T4T)"
         run: npm run tauri -- build --bundles app
 
       - name: Verify release app metadata
@@ -339,7 +339,7 @@ jobs:
           codesign --deep --force \
             --options runtime \
             --timestamp \
-            --sign "Developer ID Application: Gordon Beeming (89DBN36T4T)" \
+            --sign "${APPLE_SIGNING_IDENTITY}" \
             "${APP_BUNDLE}"
           codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}"
 
@@ -386,7 +386,7 @@ jobs:
             "${DMG}"
           codesign --force \
             --timestamp \
-            --sign "Developer ID Application: Gordon Beeming (89DBN36T4T)" \
+            --sign "${APPLE_SIGNING_IDENTITY}" \
             "${DMG}"
           codesign --verify --verbose=2 "${DMG}"
           xcrun notarytool submit "${DMG}" \


### PR DESCRIPTION
## Summary

- sign the final SSMSx DMG with the existing Developer ID identity
- notarize and staple the DMG before it is uploaded
- validate the signature, notarization ticket, disk image, and Gatekeeper assessment
- align the release runbook with the hardened distribution flow

## Why

The downloaded DMG is the outermost artifact macOS assesses. Signing and notarizing that final container gives Gatekeeper a directly stapled ticket instead of relying only on the nested app.

## User impact

Future macOS release DMGs will carry their own Developer ID signature and notarization ticket. No release is created by this PR.

## Validation

- `actionlint .github/workflows/ci.yml`
- Ruby YAML parse of `.github/workflows/ci.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Updated the macOS packaging flow to create and sign the DMG before submitting it for Apple notarization.
  * Extended automation to cover the full DMG notarization lifecycle, including ticket stapling, post-staple validation, and security assessment.
  * Standardized DMG output naming and ensured end-to-end verification during the release workflow.
  * Improved signing configuration in the release workflow by setting the signing identity at the job level.

* **Documentation**
  * Refreshed macOS release instructions to follow the new DMG creation/signing → notarization → stapling/validation order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->