### PR TITLE
Fix heredoc terminators in create-release skill

### DIFF
--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -58,53 +58,57 @@ Create a stable or beta GitHub release for `SSMSx` with the versioning and relea
    ```
 
 6. Create the release on `main`.
-   Use a published release, not a draft, when the user wants the pipeline to start now:
-   ```bash
-   gh release create v{major}.{minor} \
-     --repo GordonBeeming/ssmsx \
-     --target main \
-     --title "v{major}.{minor} - {short description}" \
-     --notes "$(cat <<'EOF'
-   # SSMSx v{major}.{minor} - {short description}
 
-   ## What's new
+Use a published release, not a draft, when the user wants the pipeline to start now:
 
-   - {list changes since the last release using git log}
+````bash
+gh release create v{major}.{minor} \
+  --repo GordonBeeming/ssmsx \
+  --target main \
+  --title "v{major}.{minor} - {short description}" \
+  --notes "$(cat <<'EOF'
+# SSMSx v{major}.{minor} - {short description}
 
-   ## Install
+## What's new
 
-   ```bash
-   brew upgrade --cask gordonbeeming/tap/ssmsx
-   ```
+- {list changes since the last release using git log}
 
-   Or download the DMG from the assets below after the release workflow completes.
-   EOF
-   )"
-   ```
-   For beta releases, use the beta tag and mark the GitHub release as a prerelease:
-   ```bash
-   gh release create v{major}.{minor}-beta.{n} \
-     --repo GordonBeeming/ssmsx \
-     --target main \
-     --prerelease \
-     --title "v{major}.{minor}-beta.{n} - {short description}" \
-     --notes "$(cat <<'EOF'
-   # SSMSx v{major}.{minor}-beta.{n} - {short description}
+## Install
 
-   ## What's new
+```bash
+brew upgrade --cask gordonbeeming/tap/ssmsx
+```
 
-   - {list changes since the last release using git log}
+Or download the DMG from the assets below after the release workflow completes.
+EOF
+)"
+````
 
-   ## Install
+For beta releases, use the beta tag and mark the GitHub release as a prerelease:
 
-   ```bash
-   brew upgrade --cask gordonbeeming/tap/ssmsx
-   ```
+````bash
+gh release create v{major}.{minor}-beta.{n} \
+  --repo GordonBeeming/ssmsx \
+  --target main \
+  --prerelease \
+  --title "v{major}.{minor}-beta.{n} - {short description}" \
+  --notes "$(cat <<'EOF'
+# SSMSx v{major}.{minor}-beta.{n} - {short description}
 
-   Or download the DMG from the assets below after the release workflow completes.
-   EOF
-   )"
-   ```
+## What's new
+
+- {list changes since the last release using git log}
+
+## Install
+
+```bash
+brew upgrade --cask gordonbeeming/tap/ssmsx
+```
+
+Or download the DMG from the assets below after the release workflow completes.
+EOF
+)"
+````
 
 7. The release pipeline will automatically:
    - Run the verification suite


### PR DESCRIPTION
## Summary

Both `gh release create` blocks in `.claude/skills/create-release/SKILL.md` (the stable release and the `-beta.{n}` prerelease) were indented under the numbered list, which put their closing `EOF` terminators (and the whole `--notes "$(cat <<'EOF' … EOF)"` bodies) at a non-zero column. Bash only treats a `<<'EOF'` heredoc as closed when the terminator line has no leading whitespace, so a literal copy-paste wouldn't close the heredoc — it would swallow the `EOF` line and corrupt the release notes.

Fixed by dedenting both release blocks to column 0 and switching their outer fences to four backticks (so the nested ` ```bash ` install blocks don't close them early), matching the already-correct `ide` and `PullUp` create-release skills. Both terminators now sit at column 0.

## Test plan

- Docs-only — no code or config changes.
- `grep -n '^EOF$'` confirms both terminators are at column 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release command examples to render nested Markdown code blocks correctly.
  * Preserved the existing stable and beta release command structures and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->