### PR TITLE
Show aliases only in recent connections

### DIFF
--- a/src/features/connection/components/ConnectionList.tsx
+++ b/src/features/connection/components/ConnectionList.tsx
@@ -6,7 +6,6 @@ import { ContextMenu, type ContextMenuItem } from "../../../shared/components/Co
 import { ConfirmDialog } from "../../../shared/components/ConfirmDialog";
 import { getEffectiveAlias, resolveColorProfile } from "../../../shared/connectionAppearance";
 import { useSettingsStore } from "../../settings";
-import { ColorProfileMarker } from "../../../shared/components/ColorProfileMarker";
 
 const AUTH_TYPE_LABELS: Record<string, string> = {
   SqlAuth: "SQL",
@@ -204,30 +203,17 @@ export function ConnectionList() {
                 <button
                   type="button"
                   aria-pressed={isSelected}
-                  className="grid min-w-0 grid-cols-[12px_minmax(0,1fr)] items-center gap-2 rounded text-left focus:outline-none focus:ring-1 focus:ring-accent-hover"
+                  className="block min-w-0 rounded text-left focus:outline-none focus:ring-1 focus:ring-accent-hover"
                   onClick={() => handleClick(c)}
                   onDoubleClick={() => handleDoubleClick(c)}
                 >
-                  <ColorProfileMarker profile={profile} size="md" />
-                  <span className="min-w-0">
-                    <span
-                      className="block break-words text-sm font-medium leading-4 text-text-primary [overflow-wrap:anywhere]"
-                      style={
-                        isSelected ? { color: profile.foreground } : undefined
-                      }
-                    >
-                      {getEffectiveAlias(c)}
-                    </span>
-                    <span
-                      className="mt-0.5 block break-words text-xs leading-4 text-text-secondary [overflow-wrap:anywhere]"
-                      style={
-                        isSelected ? { color: profile.foreground } : undefined
-                      }
-                    >
-                      {c.serverName}
-                      {c.database ? ` / ${c.database}` : ""}
-                      {c.username ? ` — ${c.username}` : ""}
-                    </span>
+                  <span
+                    className="block break-words text-sm font-medium leading-4 text-text-primary [overflow-wrap:anywhere]"
+                    style={
+                      isSelected ? { color: profile.foreground } : undefined
+                    }
+                  >
+                    {getEffectiveAlias(c)}
                   </span>
                 </button>
                 <div className="flex shrink-0 items-start gap-1">

--- a/tests/frontend/connectionAppearanceDom.test.tsx
+++ b/tests/frontend/connectionAppearanceDom.test.tsx
@@ -10,6 +10,7 @@ import { useConnectionStore } from "../../src/features/connection/store/connecti
 import { ColorProfileCombobox } from "../../src/shared/components/ColorProfileCombobox";
 import { ConfirmDialog } from "../../src/shared/components/ConfirmDialog";
 import { ConnectionStringTab } from "../../src/features/connection/components/ConnectionStringTab";
+import { ConnectionList } from "../../src/features/connection/components/ConnectionList";
 import { PropertiesTab } from "../../src/features/connection/components/PropertiesTab";
 import type { ConnectionInfo } from "../../src/features/connection/types";
 import type { CustomColorProfile } from "../../src/features/settings/types";
@@ -132,6 +133,40 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+});
+
+describe("ConnectionList", () => {
+  it("shows only the alias when present, falls back to the server name, and omits profile icons", () => {
+    const unnamedConnection: ConnectionInfo = {
+      ...linkedConnection,
+      id: "dev",
+      name: "",
+      serverName: "sql-dev",
+      database: "master",
+      username: "developer",
+    };
+    resetStores([customProfile]);
+    useConnectionStore.setState({
+      connections: [linkedConnection, unnamedConnection],
+      selectedConnection: linkedConnection,
+    });
+
+    const view = render(<ConnectionList />);
+    const aliasedConnection = screen.getByRole("button", {
+      name: "Production",
+    });
+
+    expect(aliasedConnection.textContent).toBe("Production");
+    expect(screen.queryByText("sql-prod")).toBeNull();
+    expect(screen.queryByText("master")).toBeNull();
+    expect(screen.queryByText("developer")).toBeNull();
+    expect(screen.getByRole("button", { name: "sql-dev" })).toBeTruthy();
+    expect(view.container.querySelectorAll("[data-profile-marker]")).toHaveLength(0);
+    expect(aliasedConnection.parentElement?.style.backgroundColor).toBe(
+      "rgb(0, 0, 0)"
+    );
+    expect(aliasedConnection.parentElement?.style.color).toBe("rgb(255, 255, 255)");
+  });
 });
 
 describe("ColorProfileCombobox", () => {


### PR DESCRIPTION
## Summary

I simplified the recent-connections list so an aliased connection shows only its alias. Connections without an alias still fall back to the server name.

I also removed the circular colour marker that looked like a stop-query control. The selected row still uses the connection's configured foreground and background colours.

## Test plan

- `npm run test:frontend`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Opened the native SSMSx development bundle and checked aliased, unaliased, and selected connection rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Simplified connection list entries to show only the effective connection alias or server name.
  * Removed profile markers and additional server, database, and username details from connection entries.
  * Preserved connection selection and interaction behavior.
  * Selected connections continue to display their configured profile colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->