### PR TITLE
Colour Object Explorer and editor gutter

### DIFF
--- a/src/features/explorer/components/ObjectExplorerTree.tsx
+++ b/src/features/explorer/components/ObjectExplorerTree.tsx
@@ -4,6 +4,7 @@ import {
   useState,
   useMemo,
   useCallback,
+  type CSSProperties,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -14,11 +15,18 @@ import { useTreeKeyboard } from "../hooks/useTreeKeyboard";
 import { useExplorerContextMenu } from "../hooks/useExplorerContextMenu";
 import { ContextMenu } from "../../../shared/components/ContextMenu";
 import { useSettingsStore } from "../../settings";
+import { useConnectionStore } from "../../connection";
+import { resolveColorProfile } from "../../../shared/connectionAppearance";
 
 const EXPLORER_WIDTH_STORAGE_KEY = "ssmsx.objectExplorer.width";
 const DEFAULT_EXPLORER_WIDTH = 260;
 const MIN_EXPLORER_WIDTH = 180;
 const MAX_EXPLORER_WIDTH = 720;
+
+interface ObjectExplorerStyle extends CSSProperties {
+  "--color-text-primary"?: string;
+  "--color-text-secondary"?: string;
+}
 
 function clampExplorerWidth(value: number): number {
   return Math.min(MAX_EXPLORER_WIDTH, Math.max(MIN_EXPLORER_WIDTH, value));
@@ -50,12 +58,28 @@ export function ObjectExplorerTree() {
   // Subscribe to the state that getVisibleNodes depends on
   const nodes = useExplorerStore((s) => s.nodes);
   const rootNodeIds = useExplorerStore((s) => s.rootNodeIds);
+  const selectedNodeId = useExplorerStore((s) => s.selectedNodeId);
   const getVisibleNodes = useExplorerStore((s) => s.getVisibleNodes);
   const refreshNode = useExplorerStore((s) => s.refreshNode);
   const refreshLoadedTableFolders = useExplorerStore((s) => s.refreshLoadedTableFolders);
   const groupTablesBySchema = useSettingsStore(
     (s) => s.settings.explorer.groupTablesBySchema
   );
+  const customProfiles = useSettingsStore(
+    (s) => s.settings.connections.colorProfiles
+  );
+  const connections = useConnectionStore((s) => s.connections);
+  const selectedNode = selectedNodeId ? nodes[selectedNodeId] : undefined;
+  const selectedConnection = selectedNode
+    ? connections.find((connection) => connection.id === selectedNode.connectionId)
+    : undefined;
+  const selectedProfile = selectedConnection
+    ? resolveColorProfile(
+        selectedConnection.colorProfileId,
+        customProfiles,
+        selectedConnection.color
+      )
+    : null;
   const visibleNodes = useMemo(() => getVisibleNodes(), [nodes, rootNodeIds, getVisibleNodes]);
   const parentRef = useRef<HTMLDivElement>(null);
   const previousGroupTablesBySchemaRef = useRef(groupTablesBySchema);
@@ -65,6 +89,13 @@ export function ObjectExplorerTree() {
   const handleKeyDown = useTreeKeyboard(visibleNodes);
   const getMenuItems = useExplorerContextMenu();
   const [explorerWidth, setExplorerWidth] = useState(loadExplorerWidth);
+  const explorerStyle: ObjectExplorerStyle = {
+    width: explorerWidth,
+    backgroundColor: selectedProfile?.background,
+    color: selectedProfile?.foreground,
+    "--color-text-primary": selectedProfile?.foreground,
+    "--color-text-secondary": selectedProfile?.foreground,
+  };
 
   const [contextMenu, setContextMenu] = useState<{
     x: number;
@@ -174,8 +205,9 @@ export function ObjectExplorerTree() {
 
   return (
     <div
+      data-testid="object-explorer"
       className="relative flex h-full flex-none flex-col border-r border-bg-tertiary"
-      style={{ width: explorerWidth }}
+      style={explorerStyle}
     >
       <div className="border-b border-bg-tertiary px-3 py-1.5">
         <span className="text-xs font-semibold tracking-wide text-text-secondary">

--- a/src/features/explorer/components/ObjectExplorerTree.tsx
+++ b/src/features/explorer/components/ObjectExplorerTree.tsx
@@ -24,8 +24,8 @@ const MIN_EXPLORER_WIDTH = 180;
 const MAX_EXPLORER_WIDTH = 720;
 
 interface ObjectExplorerStyle extends CSSProperties {
-  "--color-text-primary"?: string;
-  "--color-text-secondary"?: string;
+  "--object-explorer-background"?: string;
+  "--object-explorer-foreground"?: string;
 }
 
 function clampExplorerWidth(value: number): number {
@@ -93,8 +93,8 @@ export function ObjectExplorerTree() {
     width: explorerWidth,
     backgroundColor: selectedProfile?.background,
     color: selectedProfile?.foreground,
-    "--color-text-primary": selectedProfile?.foreground,
-    "--color-text-secondary": selectedProfile?.foreground,
+    "--object-explorer-background": selectedProfile?.background,
+    "--object-explorer-foreground": selectedProfile?.foreground,
   };
 
   const [contextMenu, setContextMenu] = useState<{
@@ -206,11 +206,13 @@ export function ObjectExplorerTree() {
   return (
     <div
       data-testid="object-explorer"
-      className="relative flex h-full flex-none flex-col border-r border-bg-tertiary"
+      className={`relative flex h-full flex-none flex-col border-r border-bg-tertiary ${
+        selectedProfile ? "object-explorer-profiled" : ""
+      }`}
       style={explorerStyle}
     >
       <div className="border-b border-bg-tertiary px-3 py-1.5">
-        <span className="text-xs font-semibold tracking-wide text-text-secondary">
+        <span className="object-explorer-profiled-text text-xs font-semibold tracking-wide text-text-secondary">
           OBJECT EXPLORER
         </span>
       </div>
@@ -223,7 +225,7 @@ export function ObjectExplorerTree() {
         role="tree"
       >
         {visibleNodes.length === 0 ? (
-          <div className="p-3 text-xs text-text-secondary">
+          <div className="object-explorer-profiled-text p-3 text-xs text-text-secondary">
             No connections. Connect to a server to browse objects.
           </div>
         ) : (

--- a/src/features/query/components/QueryEditor.tsx
+++ b/src/features/query/components/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useEffect } from "react";
+import { useRef, useCallback, useEffect, type CSSProperties } from "react";
 import Editor, { type OnMount, type Monaco } from "@monaco-editor/react";
 import type { editor as monacoEditor, IDisposable } from "monaco-editor";
 import { SqlCompletionProvider } from "./intellisense/SqlCompletionProvider";
@@ -10,6 +10,13 @@ interface QueryEditorProps {
   onChange: (value: string) => void;
   onExecute: (sql: string) => void;
   intellisenseMetadata?: IntelliSenseMetadata | null;
+  gutterBackground?: string;
+  gutterForeground?: string;
+}
+
+interface QueryEditorStyle extends CSSProperties {
+  "--query-gutter-background"?: string;
+  "--query-gutter-foreground"?: string;
 }
 
 export function QueryEditor({
@@ -17,6 +24,8 @@ export function QueryEditor({
   onChange,
   onExecute,
   intellisenseMetadata,
+  gutterBackground,
+  gutterForeground,
 }: QueryEditorProps) {
   const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null);
   const completionProviderRef = useRef<SqlCompletionProvider | null>(null);
@@ -107,30 +116,41 @@ export function QueryEditor({
     [onChange]
   );
 
+  const editorStyle: QueryEditorStyle = {
+    "--query-gutter-background": gutterBackground,
+    "--query-gutter-foreground": gutterForeground,
+  };
+
   return (
-    <Editor
-      defaultLanguage="sql"
-      theme={theme}
-      value={value}
-      onChange={handleChange}
-      onMount={handleMount}
-      options={{
-        minimap: { enabled: false },
-        fontSize: 14,
-        lineNumbers: "on",
-        wordWrap: "on",
-        automaticLayout: true,
-        scrollBeyondLastLine: false,
-        renderWhitespace: "none",
-        tabSize: 4,
-        insertSpaces: true,
-        suggestOnTriggerCharacters: true,
-        quickSuggestions: true,
-        // Keep line 1 off the top edge — Monaco renders it flush against the
-        // viewport top and the overflow-hidden wrapper clips the glyph tops.
-        padding: { top: 8 },
-      }}
-    />
+    <div
+      data-testid="query-editor"
+      className={`h-full ${gutterBackground ? "query-editor-profiled" : ""}`}
+      style={editorStyle}
+    >
+      <Editor
+        defaultLanguage="sql"
+        theme={theme}
+        value={value}
+        onChange={handleChange}
+        onMount={handleMount}
+        options={{
+          minimap: { enabled: false },
+          fontSize: 14,
+          lineNumbers: "on",
+          wordWrap: "on",
+          automaticLayout: true,
+          scrollBeyondLastLine: false,
+          renderWhitespace: "none",
+          tabSize: 4,
+          insertSpaces: true,
+          suggestOnTriggerCharacters: true,
+          quickSuggestions: true,
+          // Keep line 1 off the top edge — Monaco renders it flush against the
+          // viewport top and the overflow-hidden wrapper clips the glyph tops.
+          padding: { top: 8 },
+        }}
+      />
+    </div>
   );
 }
 

--- a/src/features/query/components/QueryEditor.tsx
+++ b/src/features/query/components/QueryEditor.tsx
@@ -124,7 +124,7 @@ export function QueryEditor({
   return (
     <div
       data-testid="query-editor"
-      className={`h-full ${gutterBackground ? "query-editor-profiled" : ""}`}
+      className={`h-full ${gutterBackground || gutterForeground ? "query-editor-profiled" : ""}`}
       style={editorStyle}
     >
       <Editor

--- a/src/features/query/components/QueryPanel.tsx
+++ b/src/features/query/components/QueryPanel.tsx
@@ -40,6 +40,13 @@ export function QueryPanel() {
   const activeConnection = activeTab?.connectionId
     ? connections.find((connection) => connection.id === activeTab.connectionId)
     : undefined;
+  const activeProfile = activeConnection
+    ? resolveColorProfile(
+        activeConnection.colorProfileId,
+        customProfiles,
+        activeConnection.color
+      )
+    : null;
   const splitContainerRef = useRef<HTMLDivElement>(null);
   const [resultsHeightPercent, setResultsHeightPercent] = useState(
     DEFAULT_RESULTS_HEIGHT_PERCENT
@@ -185,6 +192,8 @@ export function QueryPanel() {
             onChange={handleChange}
             onExecute={handleExecuteSql}
             intellisenseMetadata={intellisenseMetadata}
+            gutterBackground={activeProfile?.background}
+            gutterForeground={activeProfile?.foreground}
           />
         </div>
 
@@ -205,13 +214,7 @@ export function QueryPanel() {
               <QueryResultsTable
                 result={activeResult}
                 tabId={activeTabId}
-                profile={activeConnection
-                  ? resolveColorProfile(
-                      activeConnection.colorProfileId,
-                      customProfiles,
-                      activeConnection.color
-                    )
-                  : null}
+                profile={activeProfile}
               />
             </div>
           </>

--- a/src/index.css
+++ b/src/index.css
@@ -37,3 +37,11 @@ input, textarea, pre, [contenteditable] {
 .context-menu-submenu:hover > .context-menu-submenu-panel {
   display: block;
 }
+
+.query-editor-profiled .monaco-editor .margin {
+  background-color: var(--query-gutter-background) !important;
+}
+
+.query-editor-profiled .monaco-editor .line-numbers {
+  color: var(--query-gutter-foreground) !important;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -45,7 +45,11 @@ input, textarea, pre, [contenteditable] {
 }
 
 .object-explorer-profiled [role="treeitem"]:not([aria-selected="true"]):hover {
-  background-color: var(--object-explorer-background);
+  background-color: color-mix(
+    in srgb,
+    var(--object-explorer-background) 82%,
+    var(--object-explorer-foreground)
+  );
 }
 
 .query-editor-profiled .monaco-editor .margin {

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,16 @@ input, textarea, pre, [contenteditable] {
   display: block;
 }
 
+.object-explorer-profiled [role="treeitem"],
+.object-explorer-profiled [role="treeitem"] button,
+.object-explorer-profiled .object-explorer-profiled-text {
+  color: var(--object-explorer-foreground);
+}
+
+.object-explorer-profiled [role="treeitem"]:not([aria-selected="true"]):hover {
+  background-color: var(--object-explorer-background);
+}
+
 .query-editor-profiled .monaco-editor .margin {
   background-color: var(--query-gutter-background) !important;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -45,11 +45,7 @@ input, textarea, pre, [contenteditable] {
 }
 
 .object-explorer-profiled [role="treeitem"]:not([aria-selected="true"]):hover {
-  background-color: color-mix(
-    in srgb,
-    var(--object-explorer-background) 82%,
-    var(--object-explorer-foreground)
-  );
+  box-shadow: inset 0 0 0 1px var(--object-explorer-foreground);
 }
 
 .query-editor-profiled .monaco-editor .margin {

--- a/tests/frontend/connectionAppearance.test.ts
+++ b/tests/frontend/connectionAppearance.test.ts
@@ -37,6 +37,8 @@ test("custom profiles require unique names, valid hex, and AA contrast", () => {
   assert.equal(validateCustomColorProfile({ name: "prod", background: "#FFFFFF", foreground: "#111111" }, existing), "Profile names must be unique.");
   assert.equal(validateCustomColorProfile({ name: "Local", background: "red", foreground: "#111111" }, existing), "Use six-digit hex colours, for example #FEF2F2.");
   assert.equal(validateCustomColorProfile({ name: "Local", background: "#FFFFFF", foreground: "#AAAAAA" }, existing), "Foreground and background must meet 4.5:1 contrast.");
+  assert.equal(validateCustomColorProfile({ name: "Borderline", background: "#FFFFFF", foreground: "#767676" }, existing), null);
+  assert.ok(contrastRatio("#FFFFFF", "#767676") >= 4.5);
   assert.ok(contrastRatio("#FFFFFF", "#1A1A1A") >= 4.5);
 });
 

--- a/tests/frontend/queryUi.test.tsx
+++ b/tests/frontend/queryUi.test.tsx
@@ -221,6 +221,12 @@ describe("object explorer profile colours", () => {
     expect(screen.getByTestId("object-explorer").style.color).toBe(
       "rgb(255, 255, 255)"
     );
+    expect(screen.getByTestId("object-explorer").style.getPropertyValue(
+      "--object-explorer-foreground"
+    )).toBe("#FFFFFF");
+    expect(screen.getByTestId("object-explorer").style.getPropertyValue(
+      "--color-text-primary"
+    )).toBe("");
   });
 });
 

--- a/tests/frontend/queryUi.test.tsx
+++ b/tests/frontend/queryUi.test.tsx
@@ -4,11 +4,18 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryResultsTable } from "../../src/features/query/components/QueryResultsTable";
 import { QueryTabBar } from "../../src/features/query/components/QueryTabBar";
+import { QueryPanel } from "../../src/features/query/components/QueryPanel";
+import { ObjectExplorerTree } from "../../src/features/explorer/components/ObjectExplorerTree";
 import { useQueryStore } from "../../src/features/query/store/queryStore";
+import { useExplorerStore } from "../../src/features/explorer/store/explorerStore";
 import type { QueryResult, QueryTab } from "../../src/features/query/types";
 import { useConnectionStore } from "../../src/features/connection/store/connectionStore";
 import { useSettingsStore } from "../../src/features/settings/store/settingsStore";
 import type { CustomColorProfile } from "../../src/features/settings/types";
+
+vi.mock("@monaco-editor/react", () => ({
+  default: () => <div data-testid="monaco-editor" />,
+}));
 
 const nightProfile: CustomColorProfile = {
   id: "night",
@@ -50,6 +57,11 @@ function resetStores() {
     selectedConnection: null,
     activeConnectionIds: [],
     error: null,
+  });
+  useExplorerStore.setState({
+    nodes: {},
+    rootNodeIds: [],
+    selectedNodeId: null,
   });
   useSettingsStore.setState({
     settings: {
@@ -130,6 +142,85 @@ describe("query tab session and profile colours", () => {
     expect(
       screen.getByTitle("app — Query 2").parentElement?.style.borderBottomStyle
     ).toBe("solid");
+  });
+
+  it("colours only the active query editor gutter from its connection profile", () => {
+    useConnectionStore.setState({
+      connections: [
+        {
+          id: "prod",
+          name: "Production",
+          serverName: "sql-prod",
+          authType: "SqlAuth",
+          encrypt: "Mandatory",
+          trustServerCertificate: false,
+          colorProfileId: "night",
+          createdAt: "2026-07-27T00:00:00Z",
+        },
+      ],
+    });
+    useQueryStore.setState({
+      tabs: [tabs[0]],
+      activeTabId: "unpinned",
+      tabSql: { unpinned: "select 1" },
+    });
+
+    render(<QueryPanel />);
+
+    const editor = screen.getByTestId("query-editor");
+    expect(editor.style.getPropertyValue("--query-gutter-background")).toBe(
+      "#000000"
+    );
+    expect(editor.style.getPropertyValue("--query-gutter-foreground")).toBe(
+      "#FFFFFF"
+    );
+    expect(editor.style.backgroundColor).toBe("");
+  });
+});
+
+describe("object explorer profile colours", () => {
+  it("uses the selected node connection background for the explorer pane", () => {
+    useConnectionStore.setState({
+      connections: [
+        {
+          id: "prod",
+          name: "Production",
+          serverName: "sql-prod",
+          authType: "SqlAuth",
+          encrypt: "Mandatory",
+          trustServerCertificate: false,
+          colorProfileId: "night",
+          createdAt: "2026-07-27T00:00:00Z",
+        },
+      ],
+    });
+    useExplorerStore.setState({
+      nodes: {
+        "prod/server": {
+          id: "prod/server",
+          connectionId: "prod",
+          type: "server",
+          name: "Production",
+          expanded: false,
+          loading: false,
+          loaded: false,
+          children: [],
+          parentId: null,
+          hasChildren: true,
+        },
+      },
+      rootNodeIds: ["prod/server"],
+      selectedNodeId: "prod/server",
+    });
+
+    render(<ObjectExplorerTree />);
+
+    expect(screen.getByTestId("object-explorer").style.backgroundColor).toBe(
+      "rgb(0, 0, 0)"
+    );
+    expect(screen.getByTestId("object-explorer").style.color).toBe(
+      "rgb(255, 255, 255)"
+    );
   });
 });
 

--- a/tests/frontend/queryUi.test.tsx
+++ b/tests/frontend/queryUi.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryResultsTable } from "../../src/features/query/components/QueryResultsTable";
 import { QueryTabBar } from "../../src/features/query/components/QueryTabBar";
 import { QueryPanel } from "../../src/features/query/components/QueryPanel";
+import { QueryEditor } from "../../src/features/query/components/QueryEditor";
 import { ObjectExplorerTree } from "../../src/features/explorer/components/ObjectExplorerTree";
 import { useQueryStore } from "../../src/features/query/store/queryStore";
 import { useExplorerStore } from "../../src/features/explorer/store/explorerStore";
@@ -175,6 +176,23 @@ describe("query tab session and profile colours", () => {
       "#FFFFFF"
     );
     expect(editor.style.backgroundColor).toBe("");
+  });
+
+  it("profiles the gutter when only its foreground is supplied", () => {
+    render(
+      <QueryEditor
+        value="select 1"
+        onChange={() => undefined}
+        onExecute={() => undefined}
+        gutterForeground="#FFFFFF"
+      />
+    );
+
+    const editor = screen.getByTestId("query-editor");
+    expect(editor.className).toContain("query-editor-profiled");
+    expect(editor.style.getPropertyValue("--query-gutter-foreground")).toBe(
+      "#FFFFFF"
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- I apply the selected tree node's connection profile to the Object Explorer background and text.
- I apply the active query's connection profile to the line-number gutter without colouring the editor canvas or horizontal bars.
- I added DOM coverage with a dark custom profile to check the background and foreground pair.

## Test plan

- `npm run test:frontend`
- `npm run build`
- `dotnet test sidecar/Ssmsx.Sidecar.slnx --filter 'Category!=Integration'`
- `cargo test --manifest-path src-tauri/Cargo.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connection-specific color profiles now apply consistently to the object explorer, query editor gutters, and query results.
  * Explorer headings, empty states, and editor gutter text automatically reflect the selected connection’s colors.

* **Bug Fixes**
  * Improved visual consistency across connection-specific interface elements.

* **Tests**
  * Added coverage verifying profile-based colors in the query editor and object explorer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->