### PR TITLE
Scope Object Explorer colours and show rows affected

### DIFF
--- a/scripts/smoke-sidecar.mjs
+++ b/scripts/smoke-sidecar.mjs
@@ -67,7 +67,7 @@ child.on("exit", (code) => {
 
 let seq = 0;
 
-function send(method, params, { streaming = false } = {}) {
+function send(method, params, { streaming = false, allowError = false } = {}) {
   const id = `smoke-${++seq}`;
   const request = { id, method, params };
   const promise = new Promise((resolve, reject) => {
@@ -76,8 +76,11 @@ function send(method, params, { streaming = false } = {}) {
   child.stdin.write(`${JSON.stringify(request)}\n`);
   return promise.then((responses) => {
     const failed = responses.find((response) => response.error);
-    if (failed) {
+    if (failed && !allowError) {
       throw new Error(`${method} failed: ${failed.error.code} ${failed.error.message}`);
+    }
+    if (allowError) {
+      return responses;
     }
     return streaming ? responses.map((response) => response.result) : responses.at(-1).result;
   });
@@ -222,6 +225,88 @@ try {
   assert(messages.rows.length === 1, "PRINT + SELECT should return one data row");
   assert(messages.messages.some((message) => message.text.includes("hello from ssmsx smoke")), "PRINT message missing");
 
+  const affectedRows = summarizeQueryResults(
+    await send(
+      "query.execute",
+      {
+        connectionId: activeConnectionId,
+        database,
+        sql: [
+          "CREATE TABLE #SsmsxAffectedRows (Id int NOT NULL);",
+          "INSERT INTO #SsmsxAffectedRows (Id) VALUES (1), (2);",
+          "UPDATE #SsmsxAffectedRows SET Id = 3 WHERE Id = 1;",
+          "DELETE FROM #SsmsxAffectedRows WHERE Id = 2;",
+          "UPDATE #SsmsxAffectedRows SET Id = 4 WHERE Id = 999;",
+        ].join("\n"),
+      },
+      { streaming: true }
+    )
+  );
+  const affectedRowMessages = affectedRows.messages
+    .map((message) => message.text)
+    .filter((text) => /^\(\d+ rows? affected\)$/.test(text));
+  assert(
+    JSON.stringify(affectedRowMessages) === JSON.stringify(["(2 rows affected)", "(1 row affected)", "(1 row affected)", "(0 rows affected)"]),
+    `affected-row messages should preserve DML event order: ${JSON.stringify(affectedRowMessages)}`
+  );
+
+  const interleavedMessages = summarizeQueryResults(
+    await send(
+      "query.execute",
+      {
+        connectionId: activeConnectionId,
+        database,
+        sql: [
+          "CREATE TABLE #SsmsxInterleavedMessages (Id int NOT NULL);",
+          "PRINT 'before affected row';",
+          "INSERT INTO #SsmsxInterleavedMessages (Id) VALUES (1);",
+          "PRINT 'between affected rows';",
+          "UPDATE #SsmsxInterleavedMessages SET Id = 2 WHERE Id = 1;",
+          "PRINT 'after affected row';",
+        ].join("\n"),
+      },
+      { streaming: true }
+    )
+  ).messages
+    .map((message) => message.text)
+    .filter((text) => /affected row/.test(text) || /^\(\d+ rows? affected\)$/.test(text));
+  assert(
+    JSON.stringify(interleavedMessages) === JSON.stringify([
+      "before affected row",
+      "(1 row affected)",
+      "between affected rows",
+      "(1 row affected)",
+      "after affected row",
+    ]),
+    `PRINT and affected-row messages should preserve wire order: ${JSON.stringify(interleavedMessages)}`
+  );
+
+  const noCount = summarizeQueryResults(
+    await send(
+      "query.execute",
+      {
+        connectionId: activeConnectionId,
+        database,
+        sql: [
+          "CREATE TABLE #SsmsxNoCountRows (Id int NOT NULL);",
+          "SET NOCOUNT ON;",
+          "INSERT INTO #SsmsxNoCountRows (Id) VALUES (1), (2);",
+          "UPDATE #SsmsxNoCountRows SET Id = 3 WHERE Id = 1;",
+          "DELETE FROM #SsmsxNoCountRows WHERE Id = 2;",
+          "SET NOCOUNT OFF;",
+        ].join("\n"),
+      },
+      { streaming: true }
+    )
+  );
+  const noCountRowMessages = noCount.messages
+    .map((message) => message.text)
+    .filter((text) => /^\(\d+ rows? affected\)$/.test(text));
+  assert(
+    noCountRowMessages.length === 0,
+    `SET NOCOUNT ON should suppress affected-row messages: ${JSON.stringify(noCountRowMessages)}`
+  );
+
   const multiResult = summarizeQueryResults(
     await send(
       "query.execute",
@@ -240,19 +325,34 @@ try {
   assert(multiResult.resultSets[0].rows.length === 2, "first result set should return two rows");
   assert(multiResult.resultSets[1].rows.length === 3, "second result set should return three rows");
 
-  const invalid = await send(
+  const invalidResponses = await send(
     "query.execute",
     {
       connectionId: activeConnectionId,
       database,
-      sql: "SELECT * FROM dbo.TableThatDoesNotExist;",
+      sql: [
+        "CREATE TABLE #SsmsxAffectedRowsBeforeError (Id int NOT NULL);",
+        "INSERT INTO #SsmsxAffectedRowsBeforeError (Id) VALUES (1), (2);",
+        "SELECT * FROM dbo.TableThatDoesNotExist;",
+      ].join("\n"),
     },
-    { streaming: true }
-  ).then(
-    () => null,
-    (error) => error
+    { streaming: true, allowError: true }
   );
-  assert(invalid?.message.includes("QUERY_ERROR"), "invalid query should surface QUERY_ERROR");
+  const affectedRowsBeforeErrorIndex = invalidResponses.findIndex((response) =>
+    response.result?.messages?.some((message) => message.text === "(2 rows affected)")
+  );
+  const queryErrorIndex = invalidResponses.findIndex(
+    (response) => response.error?.code === "QUERY_ERROR"
+  );
+  assert(
+    affectedRowsBeforeErrorIndex >= 0,
+    "successful DML before an invalid statement should preserve its affected-row message"
+  );
+  assert(queryErrorIndex >= 0, "invalid query should surface QUERY_ERROR");
+  assert(
+    affectedRowsBeforeErrorIndex < queryErrorIndex,
+    "affected-row messages should be delivered before the later query error"
+  );
 
   const cancelId = `smoke-${++seq}`;
   const cancelPromise = new Promise((resolve, reject) => {

--- a/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
+++ b/sidecar/src/Ssmsx.Core/Query/QueryExecutor.cs
@@ -101,6 +101,12 @@ public class QueryExecutor
                 Connection = connection,
                 CommandTimeout = DefaultCommandTimeoutSeconds
             };
+            cmd.StatementCompleted += (_, args) =>
+            {
+                var message = CreateAffectedRowMessage(args.RecordCount);
+                if (message is not null)
+                    messages.Add(message);
+            };
             _cancellationManager.SetCommand(queryId, cmd);
 
             foreach (var batchSql in SplitBatches(sql))
@@ -234,11 +240,47 @@ public class QueryExecutor
 
             await onBatch(cancelledBatch);
         }
+        catch (SqlException)
+        {
+            stopwatch.Stop();
+
+            if (messages.Count > 0)
+            {
+                batchNumber++;
+                var messageBatch = new QueryExecuteResult
+                {
+                    QueryId = queryId,
+                    Batch = batchNumber,
+                    Done = false,
+                    ExecutionTimeMs = stopwatch.ElapsedMilliseconds,
+                    TotalRows = totalRows,
+                    Messages = messages,
+                    Database = connection.Database
+                };
+
+                await onBatch(messageBatch);
+            }
+
+            throw;
+        }
         finally
         {
             connection.InfoMessage -= infoMessageHandler;
             _cancellationManager.Remove(queryId);
         }
+    }
+
+    internal static QueryMessage? CreateAffectedRowMessage(int recordCount)
+    {
+        if (recordCount < 0)
+            return null;
+
+        var rowLabel = recordCount == 1 ? "row" : "rows";
+        return new QueryMessage
+        {
+            Text = $"({recordCount} {rowLabel} affected)",
+            Severity = "info"
+        };
     }
 
     internal static IEnumerable<string> SplitBatches(string sql)

--- a/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
+++ b/sidecar/tests/Ssmsx.Core.Tests/Query/QueryExecutorTests.cs
@@ -5,6 +5,26 @@ namespace Ssmsx.Core.Tests.Query;
 
 public class QueryExecutorTests
 {
+    [Theory]
+    [InlineData(-1, null)]
+    [InlineData(0, "(0 rows affected)")]
+    [InlineData(1, "(1 row affected)")]
+    [InlineData(2, "(2 rows affected)")]
+    public void CreateAffectedRowMessage_FormatsReportedRecordCounts(int recordCount, string? expectedText)
+    {
+        var message = QueryExecutor.CreateAffectedRowMessage(recordCount);
+
+        if (expectedText is null)
+        {
+            Assert.Null(message);
+            return;
+        }
+
+        Assert.NotNull(message);
+        Assert.Equal(expectedText, message.Text);
+        Assert.Equal("info", message.Severity);
+    }
+
     [Fact]
     public void SplitBatches_RecognizesStandaloneCaseInsensitiveSeparators()
     {

--- a/src/features/explorer/components/ObjectExplorerTree.tsx
+++ b/src/features/explorer/components/ObjectExplorerTree.tsx
@@ -4,7 +4,6 @@ import {
   useState,
   useMemo,
   useCallback,
-  type CSSProperties,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -22,11 +21,6 @@ const EXPLORER_WIDTH_STORAGE_KEY = "ssmsx.objectExplorer.width";
 const DEFAULT_EXPLORER_WIDTH = 260;
 const MIN_EXPLORER_WIDTH = 180;
 const MAX_EXPLORER_WIDTH = 720;
-
-interface ObjectExplorerStyle extends CSSProperties {
-  "--object-explorer-background"?: string;
-  "--object-explorer-foreground"?: string;
-}
 
 function clampExplorerWidth(value: number): number {
   return Math.min(MAX_EXPLORER_WIDTH, Math.max(MIN_EXPLORER_WIDTH, value));
@@ -58,7 +52,6 @@ export function ObjectExplorerTree() {
   // Subscribe to the state that getVisibleNodes depends on
   const nodes = useExplorerStore((s) => s.nodes);
   const rootNodeIds = useExplorerStore((s) => s.rootNodeIds);
-  const selectedNodeId = useExplorerStore((s) => s.selectedNodeId);
   const getVisibleNodes = useExplorerStore((s) => s.getVisibleNodes);
   const refreshNode = useExplorerStore((s) => s.refreshNode);
   const refreshLoadedTableFolders = useExplorerStore((s) => s.refreshLoadedTableFolders);
@@ -69,18 +62,25 @@ export function ObjectExplorerTree() {
     (s) => s.settings.connections.colorProfiles
   );
   const connections = useConnectionStore((s) => s.connections);
-  const selectedNode = selectedNodeId ? nodes[selectedNodeId] : undefined;
-  const selectedConnection = selectedNode
-    ? connections.find((connection) => connection.id === selectedNode.connectionId)
-    : undefined;
-  const selectedProfile = selectedConnection
-    ? resolveColorProfile(
-        selectedConnection.colorProfileId,
-        customProfiles,
-        selectedConnection.color
-      )
-    : null;
   const visibleNodes = useMemo(() => getVisibleNodes(), [nodes, rootNodeIds, getVisibleNodes]);
+  const connectionsById = useMemo(
+    () => new Map(connections.map((connection) => [connection.id, connection])),
+    [connections]
+  );
+  const profilesByConnectionId = useMemo(
+    () =>
+      new Map(
+        connections.map((connection) => [
+          connection.id,
+          resolveColorProfile(
+            connection.colorProfileId,
+            customProfiles,
+            connection.color
+          ),
+        ])
+      ),
+    [connections, customProfiles]
+  );
   const parentRef = useRef<HTMLDivElement>(null);
   const previousGroupTablesBySchemaRef = useRef(groupTablesBySchema);
   const resizeStartXRef = useRef(0);
@@ -89,13 +89,6 @@ export function ObjectExplorerTree() {
   const handleKeyDown = useTreeKeyboard(visibleNodes);
   const getMenuItems = useExplorerContextMenu();
   const [explorerWidth, setExplorerWidth] = useState(loadExplorerWidth);
-  const explorerStyle: ObjectExplorerStyle = {
-    width: explorerWidth,
-    backgroundColor: selectedProfile?.background,
-    color: selectedProfile?.foreground,
-    "--object-explorer-background": selectedProfile?.background,
-    "--object-explorer-foreground": selectedProfile?.foreground,
-  };
 
   const [contextMenu, setContextMenu] = useState<{
     x: number;
@@ -206,13 +199,11 @@ export function ObjectExplorerTree() {
   return (
     <div
       data-testid="object-explorer"
-      className={`relative flex h-full flex-none flex-col border-r border-bg-tertiary ${
-        selectedProfile ? "object-explorer-profiled" : ""
-      }`}
-      style={explorerStyle}
+      className="relative flex h-full flex-none flex-col border-r border-bg-tertiary"
+      style={{ width: explorerWidth }}
     >
       <div className="border-b border-bg-tertiary px-3 py-1.5">
-        <span className="object-explorer-profiled-text text-xs font-semibold tracking-wide text-text-secondary">
+        <span className="text-xs font-semibold tracking-wide text-text-secondary">
           OBJECT EXPLORER
         </span>
       </div>
@@ -225,7 +216,7 @@ export function ObjectExplorerTree() {
         role="tree"
       >
         {visibleNodes.length === 0 ? (
-          <div className="object-explorer-profiled-text p-3 text-xs text-text-secondary">
+          <div className="p-3 text-xs text-text-secondary">
             No connections. Connect to a server to browse objects.
           </div>
         ) : (
@@ -253,6 +244,8 @@ export function ObjectExplorerTree() {
                   <TreeNode
                     node={node}
                     depth={depth}
+                    connection={connectionsById.get(node.connectionId)}
+                    profile={profilesByConnectionId.get(node.connectionId)}
                     onContextMenu={handleContextMenu}
                   />
                 </div>

--- a/src/features/explorer/components/TreeNode.tsx
+++ b/src/features/explorer/components/TreeNode.tsx
@@ -1,29 +1,50 @@
+import type { CSSProperties } from "react";
+import type { ConnectionInfo } from "../../connection";
+import type { ColorProfile } from "../../settings/types";
 import type { ExplorerNode } from "../types";
 import { useExplorerStore } from "../store/explorerStore";
 import { NodeIcon } from "./NodeIcon";
-import { useConnectionStore } from "../../connection";
 import { getEffectiveAlias } from "../../../shared/connectionAppearance";
 
 interface TreeNodeProps {
   node: ExplorerNode;
   depth: number;
+  connection?: ConnectionInfo;
+  profile?: ColorProfile;
   onContextMenu: (e: React.MouseEvent, node: ExplorerNode) => void;
 }
 
-export function TreeNode({ node, depth, onContextMenu }: TreeNodeProps) {
+interface TreeNodeStyle extends CSSProperties {
+  "--object-explorer-row-background"?: string;
+  "--object-explorer-row-foreground"?: string;
+}
+
+export function TreeNode({
+  node,
+  depth,
+  connection,
+  profile,
+  onContextMenu,
+}: TreeNodeProps) {
   const { selectedNodeId, selectNode, toggleExpand } = useExplorerStore();
-  const connection = useConnectionStore((state) => state.connections.find((item) => item.id === node.connectionId));
   const isSelected = selectedNodeId === node.id;
   const label = node.type === "server" && connection ? getEffectiveAlias(connection) : node.label || node.name;
+  const rowStyle: TreeNodeStyle = {
+    paddingLeft: `${depth * 16 + 4}px`,
+    "--object-explorer-row-background": profile?.background,
+    "--object-explorer-row-foreground": profile?.foreground,
+  };
 
   return (
     <div
       className={`flex cursor-pointer items-center gap-1 py-0.5 pr-2 text-sm ${
-        isSelected
+        profile
+          ? "object-explorer-profiled-row"
+          : isSelected
           ? "bg-accent/15 text-text-primary"
           : "text-text-secondary hover:bg-bg-tertiary hover:text-text-primary"
       }`}
-      style={{ paddingLeft: `${depth * 16 + 4}px` }}
+      style={rowStyle}
       onClick={() => selectNode(node.id)}
       onDoubleClick={() => {
         if (node.hasChildren) toggleExpand(node.id);

--- a/src/index.css
+++ b/src/index.css
@@ -43,7 +43,9 @@ input, textarea, pre, [contenteditable] {
 }
 
 .object-explorer-profiled-row,
-.object-explorer-profiled-row button {
+.object-explorer-profiled-row button,
+.object-explorer-profiled-row button:hover,
+.object-explorer-profiled-row button:focus-visible {
   color: var(--object-explorer-row-foreground);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -38,14 +38,28 @@ input, textarea, pre, [contenteditable] {
   display: block;
 }
 
-.object-explorer-profiled [role="treeitem"],
-.object-explorer-profiled [role="treeitem"] button,
-.object-explorer-profiled .object-explorer-profiled-text {
-  color: var(--object-explorer-foreground);
+.object-explorer-profiled-row {
+  background-color: var(--object-explorer-row-background);
 }
 
-.object-explorer-profiled [role="treeitem"]:not([aria-selected="true"]):hover {
-  box-shadow: inset 0 0 0 1px var(--object-explorer-foreground);
+.object-explorer-profiled-row,
+.object-explorer-profiled-row button {
+  color: var(--object-explorer-row-foreground);
+}
+
+.object-explorer-profiled-row[aria-selected="true"] {
+  box-shadow: inset 3px 0 0 var(--object-explorer-row-foreground);
+}
+
+.object-explorer-profiled-row:not([aria-selected="true"]):hover {
+  box-shadow: inset 0 0 0 1px var(--object-explorer-row-foreground);
+}
+
+@media (forced-colors: active) {
+  .object-explorer-profiled-row[aria-selected="true"] {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
 }
 
 .query-editor-profiled .monaco-editor .margin {

--- a/tests/frontend/fixtures/objectExplorerStyles.html
+++ b/tests/frontend/fixtures/objectExplorerStyles.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Object Explorer style fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/tests/frontend/fixtures/objectExplorerStyles.tsx"></script>
+  </body>
+</html>

--- a/tests/frontend/fixtures/objectExplorerStyles.tsx
+++ b/tests/frontend/fixtures/objectExplorerStyles.tsx
@@ -1,0 +1,122 @@
+import { createRoot } from "react-dom/client";
+import { ObjectExplorerTree } from "../../../src/features/explorer/components/ObjectExplorerTree";
+import { useConnectionStore } from "../../../src/features/connection/store/connectionStore";
+import { useExplorerStore } from "../../../src/features/explorer/store/explorerStore";
+import { useSettingsStore } from "../../../src/features/settings/store/settingsStore";
+import type { CustomColorProfile } from "../../../src/features/settings/types";
+import "../../../src/index.css";
+
+const nightProfile: CustomColorProfile = {
+  id: "night",
+  name: "Night",
+  background: "#000000",
+  foreground: "#FFFFFF",
+  builtIn: false,
+};
+
+const boundaryProfile: CustomColorProfile = {
+  id: "boundary",
+  name: "Boundary",
+  background: "#FFFFFF",
+  foreground: "#767676",
+  builtIn: false,
+};
+
+useSettingsStore.setState({
+  settings: {
+    explorer: { groupTablesBySchema: true },
+    workspace: { persistQueryTabs: true },
+    connections: { colorProfiles: [nightProfile, boundaryProfile] },
+  },
+});
+
+useConnectionStore.setState({
+  connections: [
+    {
+      id: "production",
+      name: "Production",
+      serverName: "sql-production",
+      authType: "SqlAuth",
+      encrypt: "Mandatory",
+      trustServerCertificate: false,
+      colorProfileId: "night",
+      createdAt: "2026-08-05T00:00:00Z",
+    },
+    {
+      id: "reporting",
+      name: "Reporting",
+      serverName: "sql-reporting",
+      authType: "SqlAuth",
+      encrypt: "Mandatory",
+      trustServerCertificate: false,
+      colorProfileId: "boundary",
+      createdAt: "2026-08-05T00:00:00Z",
+    },
+  ],
+  selectedConnection: null,
+  activeConnectionIds: ["production", "reporting"],
+  error: null,
+});
+
+useExplorerStore.setState({
+  nodes: {
+    "production/server": {
+      id: "production/server",
+      connectionId: "production",
+      type: "server",
+      name: "Production",
+      expanded: true,
+      loading: false,
+      loaded: true,
+      children: ["production/master"],
+      parentId: null,
+      hasChildren: true,
+    },
+    "production/master": {
+      id: "production/master",
+      connectionId: "production",
+      type: "database",
+      name: "master",
+      expanded: false,
+      loading: false,
+      loaded: false,
+      children: [],
+      parentId: "production/server",
+      hasChildren: false,
+    },
+    "reporting/server": {
+      id: "reporting/server",
+      connectionId: "reporting",
+      type: "server",
+      name: "Reporting",
+      expanded: true,
+      loading: false,
+      loaded: true,
+      children: ["reporting/warehouse"],
+      parentId: null,
+      hasChildren: true,
+    },
+    "reporting/warehouse": {
+      id: "reporting/warehouse",
+      connectionId: "reporting",
+      type: "database",
+      name: "warehouse",
+      expanded: false,
+      loading: false,
+      loaded: false,
+      children: [],
+      parentId: "reporting/server",
+      hasChildren: false,
+    },
+  },
+  rootNodeIds: ["production/server", "reporting/server"],
+  selectedNodeId: "reporting/warehouse",
+});
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("Object Explorer fixture root is missing.");
+}
+
+root.style.height = "480px";
+createRoot(root).render(<ObjectExplorerTree />);

--- a/tests/frontend/objectExplorerStyles.test.ts
+++ b/tests/frontend/objectExplorerStyles.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import { chromium, type Browser } from "@playwright/test";
+import { createServer } from "vite";
+
+function relativeLuminance(rgb: number[]): number {
+  const channels = rgb.map((value) => {
+    const channel = value / 255;
+    return channel <= 0.04045
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4;
+  });
+  return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
+}
+
+function contrastRatio(background: string, foreground: string): number {
+  const parseRgb = (value: string) =>
+    value.match(/\d+(?:\.\d+)?/g)?.slice(0, 3).map(Number) ?? [];
+  const backgroundLuminance = relativeLuminance(parseRgb(background));
+  const foregroundLuminance = relativeLuminance(parseRgb(foreground));
+  const [lighter, darker] = [backgroundLuminance, foregroundLuminance].sort(
+    (left, right) => right - left
+  );
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+test("Object Explorer applies profile styles per subtree without tinting its shell", async () => {
+  const vite = await createServer({
+    configFile: false,
+    root: process.cwd(),
+    logLevel: "error",
+    plugins: [react(), tailwindcss()],
+    server: { host: "127.0.0.1", port: 0 },
+  });
+  await vite.listen();
+
+  const address = vite.httpServer?.address();
+  assert(address && typeof address === "object");
+
+  let browser: Browser | undefined;
+  try {
+    browser = await chromium.launch({ channel: "chrome", headless: true });
+    const page = await browser.newPage();
+    await page.goto(
+      `http://127.0.0.1:${address.port}/tests/frontend/fixtures/objectExplorerStyles.html`
+    );
+
+    const explorer = page.getByTestId("object-explorer");
+    const production = page.getByRole("treeitem", { name: "Production" });
+    const productionDatabase = page.getByRole("treeitem", { name: "master" });
+    const reporting = page.getByRole("treeitem", { name: "Reporting" });
+    const selectedDatabase = page.getByRole("treeitem", { name: "warehouse" });
+    await selectedDatabase.waitFor();
+
+    assert.equal(
+      await explorer.evaluate((element) => getComputedStyle(element).backgroundColor),
+      "rgba(0, 0, 0, 0)"
+    );
+
+    for (const row of [production, productionDatabase]) {
+      assert.equal(
+        await row.evaluate((element) => getComputedStyle(element).backgroundColor),
+        "rgb(0, 0, 0)"
+      );
+      assert.equal(
+        await row.evaluate((element) => getComputedStyle(element).color),
+        "rgb(255, 255, 255)"
+      );
+    }
+
+    for (const row of [reporting, selectedDatabase]) {
+      assert.equal(
+        await row.evaluate((element) => getComputedStyle(element).backgroundColor),
+        "rgb(255, 255, 255)"
+      );
+      assert.equal(
+        await row.evaluate((element) => getComputedStyle(element).color),
+        "rgb(118, 118, 118)"
+      );
+    }
+
+    assert.equal(await selectedDatabase.getAttribute("aria-selected"), "true");
+    assert.match(
+      await selectedDatabase.evaluate((element) => getComputedStyle(element).boxShadow),
+      /rgb\(118, 118, 118\).*3px.*inset|inset.*3px.*rgb\(118, 118, 118\)/
+    );
+
+    await production.hover();
+    assert.match(
+      await production.evaluate((element) => getComputedStyle(element).boxShadow),
+      /rgb\(255, 255, 255\).*1px.*inset|inset.*1px.*rgb\(255, 255, 255\)/
+    );
+    assert.equal(
+      await production.evaluate((element) => getComputedStyle(element).backgroundColor),
+      "rgb(0, 0, 0)"
+    );
+    assert.equal(
+      await production.evaluate((element) => getComputedStyle(element).color),
+      "rgb(255, 255, 255)"
+    );
+
+    const selectedColours = await selectedDatabase.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        background: style.backgroundColor,
+        foreground: style.color,
+      };
+    });
+    assert.ok(
+      contrastRatio(selectedColours.background, selectedColours.foreground) >= 4.5,
+      `Selected profile contrast fell below 4.5:1: ${JSON.stringify(selectedColours)}`
+    );
+
+    await page.emulateMedia({ forcedColors: "active" });
+    const forcedColourSelection = await selectedDatabase.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        outlineStyle: style.outlineStyle,
+        outlineWidth: style.outlineWidth,
+      };
+    });
+    assert.deepEqual(forcedColourSelection, {
+      outlineStyle: "solid",
+      outlineWidth: "2px",
+    });
+  } finally {
+    await browser?.close();
+    await vite.close();
+  }
+});

--- a/tests/frontend/objectExplorerStyles.test.ts
+++ b/tests/frontend/objectExplorerStyles.test.ts
@@ -101,6 +101,18 @@ test("Object Explorer applies profile styles per subtree without tinting its she
       "rgb(255, 255, 255)"
     );
 
+    const productionToggle = production.getByRole("button");
+    await productionToggle.hover();
+    assert.equal(
+      await productionToggle.evaluate((element) => getComputedStyle(element).color),
+      "rgb(255, 255, 255)"
+    );
+    await productionToggle.focus();
+    assert.equal(
+      await productionToggle.evaluate((element) => getComputedStyle(element).color),
+      "rgb(255, 255, 255)"
+    );
+
     const selectedColours = await selectedDatabase.evaluate((element) => {
       const style = getComputedStyle(element);
       return {

--- a/tests/frontend/queryUi.test.tsx
+++ b/tests/frontend/queryUi.test.tsx
@@ -96,6 +96,44 @@ beforeEach(resetStores);
 afterEach(cleanup);
 
 describe("query tab session and profile colours", () => {
+  it("keeps streamed affected-row messages before a later query error", () => {
+    useQueryStore.setState({
+      tabs: [tabs[0]],
+      activeTabId: "unpinned",
+      executionInfo: {
+        unpinned: {
+          state: "executing",
+          queryId: "query-1",
+          requestId: "request-1",
+          startTime: Date.now(),
+        },
+      },
+    });
+
+    useQueryStore.getState().handleResultsBatch({
+      queryId: "query-1",
+      requestId: "request-1",
+      batch: 1,
+      done: false,
+      messages: [{ text: "(2 rows affected)", severity: "info" }],
+    });
+    useQueryStore.getState().handleQueryError(
+      "query-1",
+      "request-1",
+      "Invalid object name 'dbo.TableThatDoesNotExist'."
+    );
+
+    const state = useQueryStore.getState();
+    expect(state.executionInfo.unpinned.state).toBe("failed");
+    expect(state.results.unpinned.messages).toEqual([
+      { text: "(2 rows affected)", severity: "info" },
+      {
+        text: "Invalid object name 'dbo.TableThatDoesNotExist'.",
+        severity: "error",
+      },
+    ]);
+  });
+
   it("round-trips pinned tabs, ordering, SQL, and the active tab through localStorage", () => {
     useQueryStore.setState({
       tabs,

--- a/tests/frontend/queryUi.test.tsx
+++ b/tests/frontend/queryUi.test.tsx
@@ -18,6 +18,25 @@ vi.mock("@monaco-editor/react", () => ({
   default: () => <div data-testid="monaco-editor" />,
 }));
 
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({
+    count,
+    estimateSize,
+  }: {
+    count: number;
+    estimateSize: () => number;
+  }) => ({
+    getTotalSize: () => count * estimateSize(),
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        key: index,
+        index,
+        size: estimateSize(),
+        start: index * estimateSize(),
+      })),
+  }),
+}));
+
 const nightProfile: CustomColorProfile = {
   id: "night",
   name: "Night",
@@ -197,7 +216,7 @@ describe("query tab session and profile colours", () => {
 });
 
 describe("object explorer profile colours", () => {
-  it("uses the selected node connection background for the explorer pane", () => {
+  it("applies each connection profile to its own explorer rows", () => {
     useConnectionStore.setState({
       connections: [
         {
@@ -210,6 +229,16 @@ describe("object explorer profile colours", () => {
           colorProfileId: "night",
           createdAt: "2026-07-27T00:00:00Z",
         },
+        {
+          id: "reporting",
+          name: "Reporting",
+          serverName: "sql-reporting",
+          authType: "SqlAuth",
+          encrypt: "Mandatory",
+          trustServerCertificate: false,
+          colorProfileId: "blue",
+          createdAt: "2026-07-27T00:00:00Z",
+        },
       ],
     });
     useExplorerStore.setState({
@@ -219,32 +248,81 @@ describe("object explorer profile colours", () => {
           connectionId: "prod",
           type: "server",
           name: "Production",
+          expanded: true,
+          loading: false,
+          loaded: true,
+          children: ["prod/master"],
+          parentId: null,
+          hasChildren: true,
+        },
+        "prod/master": {
+          id: "prod/master",
+          connectionId: "prod",
+          type: "database",
+          name: "master",
           expanded: false,
           loading: false,
           loaded: false,
           children: [],
+          parentId: "prod/server",
+          hasChildren: false,
+        },
+        "reporting/server": {
+          id: "reporting/server",
+          connectionId: "reporting",
+          type: "server",
+          name: "Reporting",
+          expanded: true,
+          loading: false,
+          loaded: true,
+          children: ["reporting/warehouse"],
           parentId: null,
           hasChildren: true,
         },
+        "reporting/warehouse": {
+          id: "reporting/warehouse",
+          connectionId: "reporting",
+          type: "database",
+          name: "warehouse",
+          expanded: false,
+          loading: false,
+          loaded: false,
+          children: [],
+          parentId: "reporting/server",
+          hasChildren: false,
+        },
       },
-      rootNodeIds: ["prod/server"],
-      selectedNodeId: "prod/server",
+      rootNodeIds: ["prod/server", "reporting/server"],
+      selectedNodeId: "prod/master",
     });
 
     render(<ObjectExplorerTree />);
 
-    expect(screen.getByTestId("object-explorer").style.backgroundColor).toBe(
-      "rgb(0, 0, 0)"
-    );
-    expect(screen.getByTestId("object-explorer").style.color).toBe(
-      "rgb(255, 255, 255)"
-    );
-    expect(screen.getByTestId("object-explorer").style.getPropertyValue(
-      "--object-explorer-foreground"
-    )).toBe("#FFFFFF");
-    expect(screen.getByTestId("object-explorer").style.getPropertyValue(
-      "--color-text-primary"
-    )).toBe("");
+    const explorer = screen.getByTestId("object-explorer");
+    const production = screen.getByRole("treeitem", { name: "Production" });
+    const master = screen.getByRole("treeitem", { name: "master" });
+    const reporting = screen.getByRole("treeitem", { name: "Reporting" });
+    const warehouse = screen.getByRole("treeitem", { name: "warehouse" });
+
+    expect(explorer.className).not.toContain("object-explorer-profiled");
+    expect(explorer.style.backgroundColor).toBe("");
+    expect(explorer.style.color).toBe("");
+
+    for (const row of [production, master]) {
+      expect(row.style.getPropertyValue("--object-explorer-row-background")).toBe("#000000");
+      expect(row.style.getPropertyValue("--object-explorer-row-foreground")).toBe("#FFFFFF");
+      expect(row.className).toContain("object-explorer-profiled-row");
+    }
+    for (const row of [reporting, warehouse]) {
+      expect(row.style.getPropertyValue("--object-explorer-row-background")).toBe("#EFF6FF");
+      expect(row.style.getPropertyValue("--object-explorer-row-foreground")).toBe("#1D4ED8");
+      expect(row.className).toContain("object-explorer-profiled-row");
+    }
+
+    expect(master.getAttribute("aria-selected")).toBe("true");
+    expect(production.getAttribute("aria-selected")).toBe("false");
+    expect(production.className).not.toContain("hover:bg-bg-tertiary");
+    expect(master.className).not.toContain("bg-accent/15");
   });
 });
 


### PR DESCRIPTION
## Summary

- Keep the Object Explorer shell neutral and apply each connection profile only to that connection's rows.
- Preserve the profile colours through hover and selection, including a visible selection outline in forced-colours mode.
- Show zero, singular, and plural SQL affected-row messages, and keep successful statement messages when a later statement fails.

## Test plan

- `npm run test:frontend`
- `npm run build`
- `dotnet test sidecar/Ssmsx.Sidecar.slnx --filter "Category!=Integration"`
- `npm run smoke:sidecar`
- `node scripts/test-sidecar-contract.mjs`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Verified the real macOS app with two differently coloured connection subtrees, affected-row messages, and a successful write followed by a SQL error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added affected-row messages for completed SQL statements, including correct singular and plural wording.
  * Preserved informational messages when a later query error occurs.
  * Improved Object Explorer styling with per-connection color profiles, selection indicators, hover states, and forced-colors support.

* **Bug Fixes**
  * Fixed message ordering and suppression behavior for `PRINT`, `SET NOCOUNT ON`, and query errors.

* **Tests**
  * Added comprehensive coverage for query messaging and Object Explorer profile styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->