### PR TITLE
Add configurable new query templates

### DIFF
--- a/src/features/query/components/QueryEditor.tsx
+++ b/src/features/query/components/QueryEditor.tsx
@@ -9,6 +9,9 @@ interface QueryEditorProps {
   value: string;
   onChange: (value: string) => void;
   onExecute: (sql: string) => void;
+  pendingCursorRequestId?: string;
+  pendingCursorOffset?: number;
+  onCursorPositionApplied?: () => void;
   intellisenseMetadata?: IntelliSenseMetadata | null;
   gutterBackground?: string;
   gutterForeground?: string;
@@ -23,6 +26,9 @@ export function QueryEditor({
   value,
   onChange,
   onExecute,
+  pendingCursorRequestId,
+  pendingCursorOffset,
+  onCursorPositionApplied,
   intellisenseMetadata,
   gutterBackground,
   gutterForeground,
@@ -32,6 +38,13 @@ export function QueryEditor({
   const disposableRef = useRef<IDisposable | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
   const theme = useAppEditorTheme();
+  const appliedCursorRequestIdRef = useRef<string | null>(null);
+  const pendingCursorOffsetRef = useRef(pendingCursorOffset);
+  const pendingCursorRequestIdRef = useRef(pendingCursorRequestId);
+  const onCursorPositionAppliedRef = useRef(onCursorPositionApplied);
+  pendingCursorOffsetRef.current = pendingCursorOffset;
+  pendingCursorRequestIdRef.current = pendingCursorRequestId;
+  onCursorPositionAppliedRef.current = onCursorPositionApplied;
 
   // Keep latest callbacks in refs so Monaco actions always call the current ones
   const onExecuteRef = useRef(onExecute);
@@ -55,6 +68,33 @@ export function QueryEditor({
     };
   }, []);
 
+  const applyPendingCursorPosition = useCallback(() => {
+    const requestId = pendingCursorRequestIdRef.current;
+    const offset = pendingCursorOffsetRef.current;
+    if (
+      requestId === undefined ||
+      offset === undefined ||
+      appliedCursorRequestIdRef.current === requestId
+    ) {
+      return;
+    }
+
+    const editor = editorRef.current;
+    const model = editor?.getModel();
+    if (!editor || !model) return;
+
+    const position = model.getPositionAt(offset);
+    editor.focus();
+    editor.setPosition(position);
+    editor.revealPositionInCenter(position);
+    appliedCursorRequestIdRef.current = requestId;
+    onCursorPositionAppliedRef.current?.();
+  }, []);
+
+  useEffect(() => {
+    applyPendingCursorPosition();
+  }, [applyPendingCursorPosition, pendingCursorOffset, pendingCursorRequestId]);
+
   // Listen for toolbar Execute; Monaco owns the current selection.
   useEffect(() => {
     const handler = () => {
@@ -70,6 +110,7 @@ export function QueryEditor({
     (editor, monaco) => {
       editorRef.current = editor;
       monacoRef.current = monaco;
+      applyPendingCursorPosition();
 
       // Register SQL completion provider (once per editor)
       const provider = new SqlCompletionProvider();
@@ -106,7 +147,7 @@ export function QueryEditor({
     },
     // Only depends on initial intellisenseMetadata — refs handle callback updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [intellisenseMetadata]
+    [applyPendingCursorPosition, intellisenseMetadata]
   );
 
   const handleChange = useCallback(

--- a/src/features/query/components/QueryEditor.tsx
+++ b/src/features/query/components/QueryEditor.tsx
@@ -42,9 +42,6 @@ export function QueryEditor({
   const pendingCursorOffsetRef = useRef(pendingCursorOffset);
   const pendingCursorRequestIdRef = useRef(pendingCursorRequestId);
   const onCursorPositionAppliedRef = useRef(onCursorPositionApplied);
-  pendingCursorOffsetRef.current = pendingCursorOffset;
-  pendingCursorRequestIdRef.current = pendingCursorRequestId;
-  onCursorPositionAppliedRef.current = onCursorPositionApplied;
 
   // Keep latest callbacks in refs so Monaco actions always call the current ones
   const onExecuteRef = useRef(onExecute);
@@ -56,6 +53,12 @@ export function QueryEditor({
       completionProviderRef.current.setMetadata(intellisenseMetadata ?? null);
     }
   }, [intellisenseMetadata]);
+
+  useEffect(() => {
+    pendingCursorOffsetRef.current = pendingCursorOffset;
+    pendingCursorRequestIdRef.current = pendingCursorRequestId;
+    onCursorPositionAppliedRef.current = onCursorPositionApplied;
+  }, [onCursorPositionApplied, pendingCursorOffset, pendingCursorRequestId]);
 
   // Dispose the Monaco completion provider on unmount.
   // registerCompletionItemProvider registers globally on the Monaco module, so

--- a/src/features/query/components/QueryPanel.tsx
+++ b/src/features/query/components/QueryPanel.tsx
@@ -28,8 +28,18 @@ function clampResultsHeight(value: number): number {
 }
 
 export function QueryPanel() {
-  const { activeTabId, tabs, tabSql, updateSql, executeQuery, cancelQuery, results, loadIntelliSense } =
-    useQueryStore();
+  const {
+    activeTabId,
+    tabs,
+    tabSql,
+    updateSql,
+    executeQuery,
+    cancelQuery,
+    results,
+    loadIntelliSense,
+    pendingCursorOffsets,
+    consumePendingCursorOffset,
+  } = useQueryStore();
   const activeConnectionIds = useConnectionStore((s) => s.activeConnectionIds);
   const connections = useConnectionStore((s) => s.connections);
   const customProfiles = useSettingsStore((s) => s.settings.connections.colorProfiles);
@@ -191,6 +201,9 @@ export function QueryPanel() {
             value={activeSql}
             onChange={handleChange}
             onExecute={handleExecuteSql}
+            pendingCursorRequestId={activeTabId}
+            pendingCursorOffset={pendingCursorOffsets[activeTabId]}
+            onCursorPositionApplied={() => consumePendingCursorOffset(activeTabId)}
             intellisenseMetadata={intellisenseMetadata}
             gutterBackground={activeProfile?.background}
             gutterForeground={activeProfile?.foreground}

--- a/src/features/query/store/queryStore.ts
+++ b/src/features/query/store/queryStore.ts
@@ -15,7 +15,9 @@ import {
   type IntelliSenseMetadata,
 } from "../api/queryApi";
 import { useConnectionStore } from "../../connection/store/connectionStore";
+import { useSettingsStore } from "../../settings";
 import { normalizeRestoredQueryTab } from "../utils/queryTabs";
+import { parseNewQueryTemplate } from "../utils/newQueryTemplate";
 
 const QUERY_SESSION_STORAGE_KEY = "ssmsx.querySession.v1";
 
@@ -43,6 +45,7 @@ interface QueryState {
   executionInfo: Record<string, TabExecutionInfo>;
   results: Record<string, QueryResult>;
   intellisenseCache: Record<string, IntelliSenseMetadata>;
+  pendingCursorOffsets: Record<string, number>;
 
   // Tab management
   addTab: (tab: QueryTab) => void;
@@ -54,6 +57,7 @@ interface QueryState {
   closeOtherTabs: (tabId: string) => void;
   closeAllTabs: () => void;
   updateTab: (tabId: string, patch: Partial<QueryTab>) => void;
+  consumePendingCursorOffset: (tabId: string) => void;
   saveSession: () => void;
   restoreSavedSession: () => boolean;
   discardSavedSession: () => void;
@@ -193,16 +197,29 @@ export const useQueryStore = create<QueryState>((set, get) => ({
   executionInfo: {},
   results: {},
   intellisenseCache: {},
+  pendingCursorOffsets: {},
 
-  addTab: (tab) =>
+  addTab: (tab) => {
+    const isBlankQuery = tab.kind !== "diagram" && tab.initialSql === undefined;
+    const template = isBlankQuery
+      ? parseNewQueryTemplate(useSettingsStore.getState().settings.queryEditor.newQueryTemplate)
+      : null;
+    const initializedTab = template ? { ...tab, initialSql: template.sql } : tab;
+
     set((state) => ({
-      tabs: [...state.tabs, tab],
-      activeTabId: tab.id,
+      tabs: [...state.tabs, initializedTab],
+      activeTabId: initializedTab.id,
       tabSql: {
         ...state.tabSql,
-        ...(tab.kind === "diagram" ? {} : { [tab.id]: tab.initialSql ?? "" }),
+        ...(initializedTab.kind === "diagram"
+          ? {}
+          : { [initializedTab.id]: initializedTab.initialSql ?? "" }),
       },
-    })),
+      pendingCursorOffsets: template
+        ? { ...state.pendingCursorOffsets, [initializedTab.id]: template.cursorOffset }
+        : state.pendingCursorOffsets,
+    }));
+  },
 
   removeTab: (id) =>
     set((state) => {
@@ -210,11 +227,13 @@ export const useQueryStore = create<QueryState>((set, get) => ({
       const { [id]: _sql, ...restSql } = state.tabSql;
       const { [id]: _exec, ...restExec } = state.executionInfo;
       const { [id]: _res, ...restResults } = state.results;
+      const { [id]: _pendingCursorOffset, ...restPendingCursorOffsets } = state.pendingCursorOffsets;
       return {
         tabs,
         tabSql: restSql,
         executionInfo: restExec,
         results: restResults,
+        pendingCursorOffsets: restPendingCursorOffsets,
         activeTabId:
           state.activeTabId === id
             ? tabs.length > 0
@@ -222,6 +241,12 @@ export const useQueryStore = create<QueryState>((set, get) => ({
               : null
             : state.activeTabId,
       };
+    }),
+
+  consumePendingCursorOffset: (tabId) =>
+    set((state) => {
+      const { [tabId]: _pendingCursorOffset, ...pendingCursorOffsets } = state.pendingCursorOffsets;
+      return { pendingCursorOffsets };
     }),
 
   setActiveTab: (id) => set({ activeTabId: id }),
@@ -273,10 +298,12 @@ export const useQueryStore = create<QueryState>((set, get) => ({
       const tabSql = { ...state.tabSql };
       const executionInfo = { ...state.executionInfo };
       const results = { ...state.results };
+      const pendingCursorOffsets = { ...state.pendingCursorOffsets };
       for (const id of removedIds) {
         delete tabSql[id];
         delete executionInfo[id];
         delete results[id];
+        delete pendingCursorOffsets[id];
       }
 
       return {
@@ -285,6 +312,7 @@ export const useQueryStore = create<QueryState>((set, get) => ({
         tabSql,
         executionInfo,
         results,
+        pendingCursorOffsets,
       };
     }),
 
@@ -295,6 +323,7 @@ export const useQueryStore = create<QueryState>((set, get) => ({
       tabSql: {},
       executionInfo: {},
       results: {},
+      pendingCursorOffsets: {},
     }),
 
   saveSession: () => {
@@ -350,6 +379,7 @@ export const useQueryStore = create<QueryState>((set, get) => ({
       tabSql,
       executionInfo: {},
       results: {},
+      pendingCursorOffsets: {},
     });
 
     return true;

--- a/src/features/query/utils/newQueryTemplate.ts
+++ b/src/features/query/utils/newQueryTemplate.ts
@@ -5,6 +5,10 @@ export interface ParsedNewQueryTemplate {
   cursorOffset: number;
 }
 
+export function hasAtMostOneCursorMarker(template: string): boolean {
+  return template.indexOf(CURSOR_MARKER) === template.lastIndexOf(CURSOR_MARKER);
+}
+
 /**
  * Removes the optional cursor marker without altering any of the template's
  * remaining whitespace. Offsets are UTF-16 indices, matching Monaco's model API.

--- a/src/features/query/utils/newQueryTemplate.ts
+++ b/src/features/query/utils/newQueryTemplate.ts
@@ -1,0 +1,24 @@
+const CURSOR_MARKER = "{{cursor}}";
+
+export interface ParsedNewQueryTemplate {
+  sql: string;
+  cursorOffset: number;
+}
+
+/**
+ * Removes the optional cursor marker without altering any of the template's
+ * remaining whitespace. Offsets are UTF-16 indices, matching Monaco's model API.
+ */
+export function parseNewQueryTemplate(template: string): ParsedNewQueryTemplate {
+  const markerOffset = template.indexOf(CURSOR_MARKER);
+  if (markerOffset === -1) {
+    return { sql: template, cursorOffset: template.length };
+  }
+
+  return {
+    sql:
+      template.slice(0, markerOffset) +
+      template.slice(markerOffset + CURSOR_MARKER.length),
+    cursorOffset: markerOffset,
+  };
+}

--- a/src/features/settings/components/SettingsDialog.tsx
+++ b/src/features/settings/components/SettingsDialog.tsx
@@ -26,13 +26,16 @@ export function SettingsDialog({ open: isOpen, onClose }: SettingsDialogProps) {
   const searchRef = useRef<HTMLInputElement>(null);
   const [searchText, setSearchText] = useState("");
   const [activeCategory, setActiveCategory] = useState("Object Explorer");
-  const [storageError, setStorageError] = useState<string | null>(null);
+  const [settingsError, setSettingsError] = useState<string | null>(null);
   const settings = useSettingsStore((state) => state.settings);
   const setGroupTablesBySchema = useSettingsStore(
     (state) => state.setGroupTablesBySchema
   );
   const setPersistQueryTabs = useSettingsStore(
     (state) => state.setPersistQueryTabs
+  );
+  const setNewQueryTemplate = useSettingsStore(
+    (state) => state.setNewQueryTemplate
   );
 
   useEffect(() => {
@@ -118,7 +121,11 @@ export function SettingsDialog({ open: isOpen, onClose }: SettingsDialogProps) {
         : settingId === "workspace.persistQueryTabs"
           ? setPersistQueryTabs(value)
           : null;
-    setStorageError(saveError);
+    setSettingsError(saveError);
+  };
+
+  const updateTemplate = (value: string): void => {
+    setSettingsError(setNewQueryTemplate(value));
   };
 
   return (
@@ -211,25 +218,36 @@ export function SettingsDialog({ open: isOpen, onClose }: SettingsDialogProps) {
                       </p>
                     </div>
 
-                    <label className="flex cursor-pointer items-center gap-2 rounded border border-bg-tertiary bg-bg-input px-3 py-2 text-sm text-text-primary hover:bg-bg-secondary">
-                      <input
-                        type="checkbox"
-                        checked={isSettingEnabled(setting.id)}
-                        onChange={(event) =>
-                          updateSetting(setting.id, event.target.checked)
-                        }
-                        className="h-4 w-4 accent-accent"
+                    {setting.type === "boolean" ? (
+                      <label className="flex cursor-pointer items-center gap-2 rounded border border-bg-tertiary bg-bg-input px-3 py-2 text-sm text-text-primary hover:bg-bg-secondary">
+                        <input
+                          type="checkbox"
+                          checked={isSettingEnabled(setting.id)}
+                          onChange={(event) =>
+                            updateSetting(setting.id, event.target.checked)
+                          }
+                          className="h-4 w-4 accent-accent"
+                        />
+                        <span>Enabled</span>
+                      </label>
+                    ) : (
+                      <textarea
+                        aria-label={setting.title}
+                        value={settings.queryEditor.newQueryTemplate}
+                        onChange={(event) => updateTemplate(event.target.value)}
+                        rows={8}
+                        spellCheck={false}
+                        className="min-h-36 w-full resize-y rounded border border-bg-tertiary bg-bg-input px-3 py-2 font-mono text-sm text-text-primary focus:border-accent-hover focus:outline-none focus:ring-1 focus:ring-accent-hover"
                       />
-                      <span>Enabled</span>
-                    </label>
+                    )}
                   </section>
                 ))}
               </div>
             )}
 
-            {storageError && (
+            {settingsError && (
               <p className="mt-4 text-xs text-error" role="alert">
-                {storageError}
+                {settingsError}
               </p>
             )}
           </div>

--- a/src/features/settings/settingsSchema.ts
+++ b/src/features/settings/settingsSchema.ts
@@ -7,6 +7,9 @@ export const defaultSettings: AppSettings = {
   workspace: {
     persistQueryTabs: true,
   },
+  queryEditor: {
+    newQueryTemplate: "\n".repeat(30) + "{{cursor}}",
+  },
   connections: {
     colorProfiles: [],
   },
@@ -32,5 +35,15 @@ export const settingsSchema: SettingDefinition[] = [
     keywords: ["query", "queries", "tabs", "restore", "startup", "session", "workspace"],
     type: "boolean",
     defaultValue: defaultSettings.workspace.persistQueryTabs,
+  },
+  {
+    id: "queryEditor.newQueryTemplate",
+    category: "Query Editor",
+    title: "New query template",
+    description:
+      "New queries insert this content exactly as written. Use the optional {{cursor}} marker to place the cursor.",
+    keywords: ["query", "new query", "template", "cursor", "whitespace", "editor"],
+    type: "template",
+    defaultValue: defaultSettings.queryEditor.newQueryTemplate,
   },
 ];

--- a/src/features/settings/store/settingsStore.ts
+++ b/src/features/settings/store/settingsStore.ts
@@ -6,6 +6,7 @@ import {
   normalizeCustomColorProfiles,
   validateCustomColorProfile,
 } from "../../../shared/connectionAppearance";
+import { hasAtMostOneCursorMarker } from "../../query/utils/newQueryTemplate";
 
 export const SETTINGS_STORAGE_KEY = "ssmsx.settings";
 export const SAVE_SETTINGS_ERROR =
@@ -29,6 +30,11 @@ function readColorProfiles(value: unknown): CustomColorProfile[] {
 
 function readString(value: unknown, fallback: string): string {
   return typeof value === "string" ? value : fallback;
+}
+
+function readNewQueryTemplate(value: unknown, fallback: string): string {
+  const template = readString(value, fallback);
+  return hasAtMostOneCursorMarker(template) ? template : fallback;
 }
 
 function readProperty(value: unknown, property: string): unknown {
@@ -73,7 +79,7 @@ export function loadSettings(): AppSettings {
         ),
       },
       queryEditor: {
-        newQueryTemplate: readString(
+        newQueryTemplate: readNewQueryTemplate(
           readProperty(queryEditor, "newQueryTemplate"),
           defaultSettings.queryEditor.newQueryTemplate
         ),
@@ -132,8 +138,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   },
 
   setNewQueryTemplate: (value) => {
-    const markerCount = value.split("{{cursor}}").length - 1;
-    if (markerCount > 1) {
+    if (!hasAtMostOneCursorMarker(value)) {
       return "New query templates can contain at most one {{cursor}} marker.";
     }
 

--- a/src/features/settings/store/settingsStore.ts
+++ b/src/features/settings/store/settingsStore.ts
@@ -15,6 +15,7 @@ interface SettingsState {
   settings: AppSettings;
   setGroupTablesBySchema: (value: boolean) => string | null;
   setPersistQueryTabs: (value: boolean) => string | null;
+  setNewQueryTemplate: (value: string) => string | null;
   saveColorProfiles: (profiles: CustomColorProfile[]) => string | null;
 }
 
@@ -26,29 +27,59 @@ function readColorProfiles(value: unknown): CustomColorProfile[] {
   return normalizeCustomColorProfiles(value);
 }
 
+function readString(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function readProperty(value: unknown, property: string): unknown {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    !Object.prototype.hasOwnProperty.call(value, property)
+  ) {
+    return undefined;
+  }
+
+  return Reflect.get(value, property);
+}
+
 export function loadSettings(): AppSettings {
   try {
     const storedValue = window.localStorage.getItem(SETTINGS_STORAGE_KEY);
     if (!storedValue) return defaultSettings;
 
-    const parsed = JSON.parse(storedValue) as Partial<AppSettings> | null;
-    if (!parsed || typeof parsed !== "object") return defaultSettings;
+    const parsed: unknown = JSON.parse(storedValue);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return defaultSettings;
+    }
+
+    const explorer = readProperty(parsed, "explorer");
+    const workspace = readProperty(parsed, "workspace");
+    const queryEditor = readProperty(parsed, "queryEditor");
+    const connections = readProperty(parsed, "connections");
 
     return {
       explorer: {
         groupTablesBySchema: readBoolean(
-          parsed.explorer?.groupTablesBySchema,
+          readProperty(explorer, "groupTablesBySchema"),
           defaultSettings.explorer.groupTablesBySchema
         ),
       },
       workspace: {
         persistQueryTabs: readBoolean(
-          parsed.workspace?.persistQueryTabs,
+          readProperty(workspace, "persistQueryTabs"),
           defaultSettings.workspace.persistQueryTabs
         ),
       },
+      queryEditor: {
+        newQueryTemplate: readString(
+          readProperty(queryEditor, "newQueryTemplate"),
+          defaultSettings.queryEditor.newQueryTemplate
+        ),
+      },
       connections: {
-        colorProfiles: readColorProfiles(parsed.connections?.colorProfiles),
+        colorProfiles: readColorProfiles(readProperty(connections, "colorProfiles")),
       },
     };
   } catch (cause) {
@@ -92,6 +123,26 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       workspace: {
         ...current.workspace,
         persistQueryTabs: value,
+      },
+    };
+    const saveError = saveSettings(settings);
+    if (saveError) return saveError;
+    set({ settings });
+    return null;
+  },
+
+  setNewQueryTemplate: (value) => {
+    const markerCount = value.split("{{cursor}}").length - 1;
+    if (markerCount > 1) {
+      return "New query templates can contain at most one {{cursor}} marker.";
+    }
+
+    const current = get().settings;
+    const settings: AppSettings = {
+      ...current,
+      queryEditor: {
+        ...current.queryEditor,
+        newQueryTemplate: value,
       },
     };
     const saveError = saveSettings(settings);

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -1,6 +1,6 @@
-export type SettingValue = boolean;
+export type SettingValue = boolean | string;
 
-export interface SettingDefinition {
+export interface BooleanSettingDefinition {
   id: string;
   category: string;
   title: string;
@@ -10,12 +10,29 @@ export interface SettingDefinition {
   defaultValue: boolean;
 }
 
+export interface TemplateSettingDefinition {
+  id: string;
+  category: string;
+  title: string;
+  description: string;
+  keywords: string[];
+  type: "template";
+  defaultValue: string;
+}
+
+export type SettingDefinition =
+  | BooleanSettingDefinition
+  | TemplateSettingDefinition;
+
 export interface AppSettings {
   explorer: {
     groupTablesBySchema: boolean;
   };
   workspace: {
     persistQueryTabs: boolean;
+  };
+  queryEditor: {
+    newQueryTemplate: string;
   };
   connections: {
     colorProfiles: CustomColorProfile[];

--- a/tests/frontend/connectionAppearanceDom.test.tsx
+++ b/tests/frontend/connectionAppearanceDom.test.tsx
@@ -5,7 +5,11 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectionProfilesPanel } from "../../src/features/settings/components/ConnectionProfilesPanel";
 import { SettingsDialog } from "../../src/features/settings/components/SettingsDialog";
-import { useSettingsStore } from "../../src/features/settings/store/settingsStore";
+import {
+  loadSettings,
+  SETTINGS_STORAGE_KEY,
+  useSettingsStore,
+} from "../../src/features/settings/store/settingsStore";
 import { useConnectionStore } from "../../src/features/connection/store/connectionStore";
 import { ColorProfileCombobox } from "../../src/shared/components/ColorProfileCombobox";
 import { ConfirmDialog } from "../../src/shared/components/ConfirmDialog";
@@ -53,6 +57,7 @@ function resetStores(profiles: CustomColorProfile[] = []) {
     settings: {
       explorer: { groupTablesBySchema: true },
       workspace: { persistQueryTabs: true },
+      queryEditor: { newQueryTemplate: "\n".repeat(30) + "{{cursor}}" },
       connections: { colorProfiles: profiles },
     },
   });
@@ -685,6 +690,86 @@ describe("SettingsDialog", () => {
         .getByRole("button", { name: "Connections" })
         .getAttribute("aria-current")
     ).toBe("page");
+  });
+
+  it("migrates missing or non-string templates while preserving exact string values", () => {
+    window.localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({ queryEditor: { newQueryTemplate: null } })
+    );
+    expect(loadSettings().queryEditor.newQueryTemplate).toBe(
+      "\n".repeat(30) + "{{cursor}}"
+    );
+
+    const whitespaceTemplate = "  SELECT 1;  \n\n";
+    window.localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({ queryEditor: { newQueryTemplate: whitespaceTemplate } })
+    );
+    expect(loadSettings().queryEditor.newQueryTemplate).toBe(whitespaceTemplate);
+
+    window.localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({ queryEditor: { newQueryTemplate: "" } })
+    );
+    expect(loadSettings().queryEditor.newQueryTemplate).toBe("");
+  });
+
+  it("rejects duplicate markers without changing settings", () => {
+    const originalTemplate = useSettingsStore.getState().settings.queryEditor.newQueryTemplate;
+    const setNewQueryTemplate = useSettingsStore.getState().setNewQueryTemplate;
+
+    expect(setNewQueryTemplate("{{cursor}} SELECT {{cursor}}")).toContain(
+      "at most one"
+    );
+    expect(useSettingsStore.getState().settings.queryEditor.newQueryTemplate).toBe(
+      originalTemplate
+    );
+  });
+
+  it("keeps the template unchanged when saving fails", () => {
+    const originalTemplate = useSettingsStore.getState().settings.queryEditor.newQueryTemplate;
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage is unavailable", "QuotaExceededError");
+    });
+
+    expect(useSettingsStore.getState().setNewQueryTemplate("SELECT 1;")).toContain(
+      "Could not save settings"
+    );
+    expect(useSettingsStore.getState().settings.queryEditor.newQueryTemplate).toBe(
+      originalTemplate
+    );
+  });
+
+  it("edits the accessible template textarea without normalizing its content", () => {
+    render(<SettingsDialog open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Query Editor" }));
+    const textarea = screen.getByRole("textbox", { name: "New query template" });
+    const template = "  SELECT 1;  \n\n";
+
+    fireEvent.change(textarea, { target: { value: template } });
+
+    expect((textarea as HTMLTextAreaElement).value).toBe(template);
+    expect(useSettingsStore.getState().settings.queryEditor.newQueryTemplate).toBe(
+      template
+    );
+  });
+
+  it("shows template validation and storage errors in the settings alert", () => {
+    render(<SettingsDialog open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Query Editor" }));
+    const textarea = screen.getByRole("textbox", { name: "New query template" });
+
+    fireEvent.change(textarea, { target: { value: "{{cursor}}{{cursor}}" } });
+    expect(screen.getByRole("alert").textContent).toContain("at most one");
+
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage is unavailable", "QuotaExceededError");
+    });
+    fireEvent.change(textarea, { target: { value: "SELECT 1;" } });
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Could not save settings"
+    );
   });
 });
 

--- a/tests/frontend/connectionAppearanceDom.test.tsx
+++ b/tests/frontend/connectionAppearanceDom.test.tsx
@@ -713,6 +713,14 @@ describe("SettingsDialog", () => {
       JSON.stringify({ queryEditor: { newQueryTemplate: "" } })
     );
     expect(loadSettings().queryEditor.newQueryTemplate).toBe("");
+
+    window.localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({ queryEditor: { newQueryTemplate: "{{cursor}} SELECT {{cursor}}" } })
+    );
+    expect(loadSettings().queryEditor.newQueryTemplate).toBe(
+      "\n".repeat(30) + "{{cursor}}"
+    );
   });
 
   it("rejects duplicate markers without changing settings", () => {

--- a/tests/frontend/fixtures/newQueryTemplate.html
+++ b/tests/frontend/fixtures/newQueryTemplate.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>New query template acceptance fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/tests/frontend/fixtures/newQueryTemplate.tsx"></script>
+  </body>
+</html>

--- a/tests/frontend/fixtures/newQueryTemplate.tsx
+++ b/tests/frontend/fixtures/newQueryTemplate.tsx
@@ -43,7 +43,7 @@ useConnectionStore.setState({
       authType: "SqlAuth",
       encrypt: "Mandatory",
       trustServerCertificate: false,
-      createdAt: "2026-08-07T00:00:00Z",
+      createdAt: "2026-08-05T00:00:00Z",
     },
   ],
   activeConnectionIds: [CONNECTION_ID],

--- a/tests/frontend/fixtures/newQueryTemplate.tsx
+++ b/tests/frontend/fixtures/newQueryTemplate.tsx
@@ -1,0 +1,120 @@
+import { createRoot } from "react-dom/client";
+import { useEffect, useState } from "react";
+import { useConnectionStore } from "../../../src/features/connection";
+import { QueryPanel, QueryTabBar, useQueryStore } from "../../../src/features/query";
+import { SettingsDialog, useSettingsStore } from "../../../src/features/settings";
+import type { QueryTab } from "../../../src/features/query";
+import "../../../src/index.css";
+
+const CONNECTION_ID = "acceptance-connection";
+const GENERATED_SQL = "SELECT name FROM sys.databases;\n";
+
+let tabNumber = 0;
+
+interface AcceptanceFixture {
+  addGeneratedQuery: () => void;
+  getActiveTab: () => QueryTab | undefined;
+  getActiveSql: () => string;
+  isActiveTabDirty: () => boolean;
+}
+
+declare global {
+  interface Window {
+    ssmsxNewQueryTemplateFixture?: AcceptanceFixture;
+  }
+}
+
+useSettingsStore.setState({
+  settings: {
+    explorer: { groupTablesBySchema: true },
+    workspace: { persistQueryTabs: false },
+    queryEditor: { newQueryTemplate: "\n".repeat(30) + "{{cursor}}" },
+    connections: { colorProfiles: [] },
+  },
+});
+
+useConnectionStore.setState({
+  connections: [
+    {
+      id: CONNECTION_ID,
+      name: "Acceptance SQL Server",
+      serverName: "localhost",
+      database: "master",
+      authType: "SqlAuth",
+      encrypt: "Mandatory",
+      trustServerCertificate: false,
+      createdAt: "2026-08-07T00:00:00Z",
+    },
+  ],
+  activeConnectionIds: [CONNECTION_ID],
+  error: null,
+});
+
+function nextTab(title: string, initialSql?: string): QueryTab {
+  tabNumber += 1;
+  return {
+    id: `acceptance-query-${tabNumber}`,
+    kind: "query",
+    connectionId: CONNECTION_ID,
+    database: "master",
+    title,
+    ...(initialSql === undefined ? {} : { initialSql }),
+  };
+}
+
+function AcceptanceFixtureApp() {
+  const [settingsOpen, setSettingsOpen] = useState(true);
+
+  useEffect(() => {
+    const createBlankQuery = () => {
+      useQueryStore.getState().addTab(nextTab(`Query ${tabNumber + 1}`));
+    };
+    window.addEventListener("query:new-tab", createBlankQuery);
+    return () => window.removeEventListener("query:new-tab", createBlankQuery);
+  }, []);
+
+  useEffect(() => {
+    window.ssmsxNewQueryTemplateFixture = {
+      addGeneratedQuery: () => {
+        useQueryStore.getState().addTab(nextTab("Generated SQL", GENERATED_SQL));
+      },
+      getActiveTab: () => {
+        const state = useQueryStore.getState();
+        return state.tabs.find((tab) => tab.id === state.activeTabId);
+      },
+      getActiveSql: () => {
+        const state = useQueryStore.getState();
+        return state.activeTabId ? (state.tabSql[state.activeTabId] ?? "") : "";
+      },
+      isActiveTabDirty: () => {
+        const state = useQueryStore.getState();
+        return state.activeTabId ? state.isTabDirty(state.activeTabId) : false;
+      },
+    };
+
+    return () => {
+      delete window.ssmsxNewQueryTemplateFixture;
+    };
+  }, []);
+
+  return (
+    <main className="flex h-screen min-h-0 flex-col bg-bg-primary text-text-primary">
+      <header className="flex items-center justify-between border-b border-bg-tertiary px-4 py-2">
+        <h1 className="m-0 text-base font-semibold">New query template acceptance</h1>
+        <button type="button" onClick={() => setSettingsOpen(true)}>
+          Open settings
+        </button>
+      </header>
+      <QueryTabBar />
+      <QueryPanel />
+      <SettingsDialog open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+    </main>
+  );
+}
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("New query template fixture root is missing.");
+}
+
+createRoot(root).render(<AcceptanceFixtureApp />);

--- a/tests/frontend/fixtures/objectExplorerStyles.tsx
+++ b/tests/frontend/fixtures/objectExplorerStyles.tsx
@@ -26,6 +26,7 @@ useSettingsStore.setState({
   settings: {
     explorer: { groupTablesBySchema: true },
     workspace: { persistQueryTabs: true },
+    queryEditor: { newQueryTemplate: "\n".repeat(30) + "{{cursor}}" },
     connections: { colorProfiles: [nightProfile, boundaryProfile] },
   },
 });

--- a/tests/frontend/newQueryTemplate.test.ts
+++ b/tests/frontend/newQueryTemplate.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { parseNewQueryTemplate } from "../../src/features/query/utils/newQueryTemplate.ts";
+import {
+  hasAtMostOneCursorMarker,
+  parseNewQueryTemplate,
+} from "../../src/features/query/utils/newQueryTemplate.ts";
 
 test("preserves whitespace around a cursor marker", () => {
   const template = "  SELECT 1  \n{{cursor}}\n  ";
@@ -33,4 +36,9 @@ test("uses the exact end when no marker is present, including an empty template"
     cursorOffset: 9,
   });
   assert.deepEqual(parseNewQueryTemplate(""), { sql: "", cursorOffset: 0 });
+});
+
+test("rejects templates with more than one cursor marker", () => {
+  assert.equal(hasAtMostOneCursorMarker("{{cursor}} SELECT {{cursor}}"), false);
+  assert.equal(hasAtMostOneCursorMarker("SELECT {{cursor}}"), true);
 });

--- a/tests/frontend/newQueryTemplate.test.ts
+++ b/tests/frontend/newQueryTemplate.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseNewQueryTemplate } from "../../src/features/query/utils/newQueryTemplate.ts";
+
+test("preserves whitespace around a cursor marker", () => {
+  const template = "  SELECT 1  \n{{cursor}}\n  ";
+
+  assert.deepEqual(parseNewQueryTemplate(template), {
+    sql: "  SELECT 1  \n\n  ",
+    cursorOffset: 13,
+  });
+});
+
+test("places the default template cursor on line 31", () => {
+  const template = "\n".repeat(30) + "{{cursor}}";
+
+  assert.deepEqual(parseNewQueryTemplate(template), {
+    sql: "\n".repeat(30),
+    cursorOffset: 30,
+  });
+});
+
+test("uses a marker in the middle of a template", () => {
+  assert.deepEqual(parseNewQueryTemplate("SELECT {{cursor}}FROM dbo.Users"), {
+    sql: "SELECT FROM dbo.Users",
+    cursorOffset: 7,
+  });
+});
+
+test("uses the exact end when no marker is present, including an empty template", () => {
+  assert.deepEqual(parseNewQueryTemplate("SELECT 1\n"), {
+    sql: "SELECT 1\n",
+    cursorOffset: 9,
+  });
+  assert.deepEqual(parseNewQueryTemplate(""), { sql: "", cursorOffset: 0 });
+});

--- a/tests/frontend/newQueryTemplateBrowser.test.ts
+++ b/tests/frontend/newQueryTemplateBrowser.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import { chromium, type Browser } from "@playwright/test";
+import { createServer } from "vite";
+
+const TEMPLATE = "  BEGIN TRANSACTION;\n    {{cursor}}SELECT 1;\nCOMMIT;  \n";
+const PROCESSED_TEMPLATE = "  BEGIN TRANSACTION;\n    SELECT 1;\nCOMMIT;  \n";
+const CURSOR_SENTINEL = "/* here */";
+const SCREENSHOT_PATH = join(tmpdir(), "ssmsx-new-query-template-browser.png");
+
+interface FixtureWindow extends Window {
+  ssmsxNewQueryTemplateFixture?: {
+    addGeneratedQuery: () => void;
+    getActiveTab: () => { initialSql?: string; title: string } | undefined;
+    getActiveSql: () => string;
+    isActiveTabDirty: () => boolean;
+  };
+}
+
+test("new query templates preserve whitespace and place the Monaco cursor", async () => {
+  const vite = await createServer({
+    configFile: false,
+    root: process.cwd(),
+    logLevel: "error",
+    plugins: [react(), tailwindcss()],
+    server: { host: "127.0.0.1", port: 0 },
+  });
+  await vite.listen();
+
+  const address = vite.httpServer?.address();
+  assert(address && typeof address === "object");
+
+  let browser: Browser | undefined;
+  try {
+    browser = await chromium.launch({ channel: "chrome", headless: true });
+    const page = await browser.newPage({ viewport: { width: 960, height: 720 } });
+    await page.goto(
+      `http://127.0.0.1:${address.port}/tests/frontend/fixtures/newQueryTemplate.html`
+    );
+
+    await page.getByRole("button", { name: "Query Editor" }).click();
+    const templateControl = page.getByRole("textbox", { name: "New query template" });
+    await templateControl.waitFor();
+    await templateControl.fill(TEMPLATE);
+
+    const storedTemplate = await page.evaluate(() => {
+      const raw = window.localStorage.getItem("ssmsx.settings");
+      if (!raw) return null;
+      const parsed: unknown = JSON.parse(raw);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        return null;
+      }
+      const queryEditor = Reflect.get(parsed, "queryEditor");
+      if (typeof queryEditor !== "object" || queryEditor === null || Array.isArray(queryEditor)) {
+        return null;
+      }
+      const template = Reflect.get(queryEditor, "newQueryTemplate");
+      return typeof template === "string" ? template : null;
+    });
+    assert.equal(storedTemplate, TEMPLATE);
+
+    const dialog = page.getByRole("dialog");
+    const dialogBox = await dialog.boundingBox();
+    const controlBox = await templateControl.boundingBox();
+    assert(dialogBox && controlBox);
+    assert.ok(dialogBox.x >= 0 && dialogBox.y >= 0);
+    assert.ok(dialogBox.x + dialogBox.width <= 960 && dialogBox.y + dialogBox.height <= 720);
+    assert.ok(controlBox.width >= 400 && controlBox.height >= 140);
+    await page.screenshot({ path: SCREENSHOT_PATH });
+    assert.ok(existsSync(SCREENSHOT_PATH));
+
+    await page.getByRole("button", { name: "Close" }).click();
+    await page.getByTitle(/New Query/).click();
+    const monacoEditor = page.locator(".monaco-editor");
+    await monacoEditor.waitFor();
+    await page.waitForFunction(() => {
+      const editor = document.querySelector(".monaco-editor");
+      return editor?.contains(document.activeElement) ?? false;
+    });
+
+    const blankQuery = await page.evaluate(() => {
+      const fixture = (window as FixtureWindow).ssmsxNewQueryTemplateFixture;
+      return fixture
+        ? {
+            sql: fixture.getActiveSql(),
+            dirty: fixture.isActiveTabDirty(),
+          }
+        : null;
+    });
+    assert.deepEqual(blankQuery, { sql: PROCESSED_TEMPLATE, dirty: false });
+
+    await page.keyboard.insertText(CURSOR_SENTINEL);
+    const observedMonacoValue = await page.evaluate(() => {
+      return (window as FixtureWindow).ssmsxNewQueryTemplateFixture?.getActiveSql() ?? null;
+    });
+    assert.equal(
+      observedMonacoValue,
+      "  BEGIN TRANSACTION;\n    /* here */SELECT 1;\nCOMMIT;  \n"
+    );
+
+    const generatedQuery = await page.evaluate(() => {
+      const fixture = (window as FixtureWindow).ssmsxNewQueryTemplateFixture;
+      fixture?.addGeneratedQuery();
+      const activeTab = fixture?.getActiveTab();
+      return {
+        initialSql: activeTab?.initialSql ?? null,
+        sql: fixture?.getActiveSql() ?? null,
+      };
+    });
+    assert.deepEqual(generatedQuery, {
+      initialSql: "SELECT name FROM sys.databases;\n",
+      sql: "SELECT name FROM sys.databases;\n",
+    });
+
+    console.log(
+      `New-query screenshot: ${SCREENSHOT_PATH} (960x720); Monaco value observed with cursor insertion at line 2, column 5.`
+    );
+  } finally {
+    await browser?.close();
+    await vite.close();
+  }
+});

--- a/tests/frontend/newQueryTemplateBrowser.test.ts
+++ b/tests/frontend/newQueryTemplateBrowser.test.ts
@@ -117,9 +117,6 @@ test("new query templates preserve whitespace and place the Monaco cursor", asyn
       sql: "SELECT name FROM sys.databases;\n",
     });
 
-    console.log(
-      `New-query screenshot: ${SCREENSHOT_PATH} (960x720); Monaco value observed with cursor insertion at line 2, column 5.`
-    );
   } finally {
     await browser?.close();
     await vite.close();

--- a/tests/frontend/queryUi.test.tsx
+++ b/tests/frontend/queryUi.test.tsx
@@ -71,6 +71,7 @@ function resetStores() {
     executionInfo: {},
     results: {},
     intellisenseCache: {},
+    pendingCursorOffsets: {},
   });
   useConnectionStore.setState({
     connections: [],
@@ -87,6 +88,7 @@ function resetStores() {
     settings: {
       explorer: { groupTablesBySchema: true },
       workspace: { persistQueryTabs: true },
+      queryEditor: { newQueryTemplate: "\n".repeat(30) + "{{cursor}}" },
       connections: { colorProfiles: [nightProfile] },
     },
   });
@@ -160,6 +162,80 @@ describe("query tab session and profile colours", () => {
       unpinned: "select 1",
       pinned: "select 2",
     });
+    expect(useQueryStore.getState().pendingCursorOffsets).toEqual({});
+  });
+
+  it("initializes blank queries from the template without marking them dirty", () => {
+    useSettingsStore.setState((state) => ({
+      settings: {
+        ...state.settings,
+        queryEditor: { newQueryTemplate: "SELECT {{cursor}}FROM dbo.Users\n" },
+      },
+    }));
+
+    useQueryStore.getState().addTab({
+      id: "templated",
+      connectionId: null,
+      database: "",
+      title: "Query 1",
+    });
+
+    const state = useQueryStore.getState();
+    expect(state.tabs[0].initialSql).toBe("SELECT FROM dbo.Users\n");
+    expect(state.tabSql.templated).toBe("SELECT FROM dbo.Users\n");
+    expect(state.pendingCursorOffsets).toEqual({ templated: 7 });
+    expect(state.isTabDirty("templated")).toBe(false);
+  });
+
+  it("does not apply the template to generated scripts", () => {
+    useQueryStore.getState().addTab({
+      id: "generated",
+      connectionId: "prod",
+      database: "master",
+      initialSql: "SELECT * FROM sys.databases;\n",
+      title: "Select Top 1000 Rows",
+    });
+
+    const state = useQueryStore.getState();
+    expect(state.tabs[0].initialSql).toBe("SELECT * FROM sys.databases;\n");
+    expect(state.tabSql.generated).toBe("SELECT * FROM sys.databases;\n");
+    expect(state.pendingCursorOffsets).toEqual({});
+  });
+
+  it("consumes and cleans pending cursor positions when tabs close", () => {
+    useQueryStore.setState({
+      tabs: [tabs[0], tabs[1]],
+      activeTabId: "unpinned",
+      tabSql: { unpinned: "", pinned: "" },
+      pendingCursorOffsets: { unpinned: 1, pinned: 2 },
+    });
+
+    useQueryStore.getState().consumePendingCursorOffset("unpinned");
+    expect(useQueryStore.getState().pendingCursorOffsets).toEqual({ pinned: 2 });
+
+    useQueryStore.getState().closeOtherTabs("unpinned");
+    expect(useQueryStore.getState().pendingCursorOffsets).toEqual({});
+
+    useQueryStore.setState({ pendingCursorOffsets: { unpinned: 1 } });
+    useQueryStore.getState().removeTab("unpinned");
+    expect(useQueryStore.getState().pendingCursorOffsets).toEqual({});
+  });
+
+  it("does not persist cursor positions into saved query sessions", () => {
+    useQueryStore.setState({
+      tabs: [tabs[0]],
+      activeTabId: "unpinned",
+      tabSql: { unpinned: "select 1" },
+      pendingCursorOffsets: { unpinned: 4 },
+    });
+
+    useQueryStore.getState().saveSession();
+    const saved = window.localStorage.getItem("ssmsx.querySession.v1");
+    expect(saved).not.toBeNull();
+    expect(JSON.parse(saved ?? "{}")).not.toHaveProperty("pendingCursorOffsets");
+
+    expect(useQueryStore.getState().restoreSavedSession()).toBe(true);
+    expect(useQueryStore.getState().pendingCursorOffsets).toEqual({});
   });
 
   it("renders wrapping tab bands with both profile colours on active and inactive tabs", () => {


### PR DESCRIPTION
## Summary

- Add a Query Editor setting for the exact text inserted into explicit new queries.
- Preserve every template whitespace character and support one optional `{{cursor}}` marker for caret placement.
- Default new queries to 30 blank lines while leaving generated SQL unchanged.

## Test plan

- `npm run test:frontend` — 16 Node tests and 36 Vitest tests passed.
- `npm run build`
- `git diff --check`
- Headless browser acceptance at 960×720, including exact storage, cursor placement, clean-tab state, and generated-query isolation.

Native app interaction was not run; this slice used the approved headless validation path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable templates for newly created query tabs.
  * Added `{{cursor}}` placement to position the editor cursor automatically.
  * Added query-template editing in Settings with whitespace preservation and validation.
  * Added persistence for the new template setting.

* **Bug Fixes**
  * Improved recovery when saved settings are invalid or unavailable.
  * Cleaned up cursor-placement state when tabs are closed, restored, or cleared.

* **Tests**
  * Added coverage for template parsing, persistence, validation, cursor placement, and browser behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->