### PR TITLE
Improve query templates and message selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2678,9 +2678,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3297,9 +3297,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "vitest": "^4.1.10"
   },
   "overrides": {
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.13",
+    "nanoid": "3.3.17",
     "postcss": "8.5.23"
   }
 }

--- a/src/features/query/components/QueryResultsTable.tsx
+++ b/src/features/query/components/QueryResultsTable.tsx
@@ -112,6 +112,7 @@ export function QueryResultsTable({ result, profile, tabId }: QueryResultsTableP
   const [copyStatus, setCopyStatus] = useState<string | null>(null);
   const [columnSizing, setColumnSizing] = useState<ColumnSizing | null>(null);
   const gridRef = useRef<HTMLDivElement>(null);
+  const messagesRef = useRef<HTMLDivElement>(null);
   const resizeCleanupRef = useRef<(() => void) | null>(null);
   // Read inside the per-cell onMouseEnter handler; a ref avoids re-subscribing
   // every cell on each drag-state change.
@@ -402,6 +403,30 @@ export function QueryResultsTable({ result, profile, tabId }: QueryResultsTableP
     ]
   );
 
+  const handleMessagesKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (
+        activeTab !== "messages" ||
+        !(event.metaKey || event.ctrlKey) ||
+        event.key.toLowerCase() !== "a"
+      ) {
+        return;
+      }
+
+      const messages = messagesRef.current;
+      const selection = window.getSelection();
+      if (!messages || !selection) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      const range = document.createRange();
+      range.selectNodeContents(messages);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    },
+    [activeTab]
+  );
+
   const handleCellContextMenu = useCallback(
     (event: ReactMouseEvent, rowIndex: number, colIndex: number) => {
       event.preventDefault();
@@ -478,7 +503,10 @@ export function QueryResultsTable({ result, profile, tabId }: QueryResultsTableP
   const scrollEndPadding = <div className="h-6 flex-none" aria-hidden="true" />;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div
+      className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      onKeyDown={handleMessagesKeyDown}
+    >
       {/* Tab header — both tabs are clickable when present */}
       <div
         data-testid="result-tab-strip"
@@ -695,7 +723,13 @@ export function QueryResultsTable({ result, profile, tabId }: QueryResultsTableP
       {/* Messages — select-text re-enables text selection here (body sets
           user-select: none) so message/error text can be selected and copied. */}
       {activeTab === "messages" && hasMessages && (
-        <div className="min-h-0 flex-1 overflow-auto select-text p-2">
+        <div
+          ref={messagesRef}
+          aria-label="Query messages"
+          className="min-h-0 flex-1 overflow-auto select-text p-2 focus-visible:outline focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-accent"
+          role="region"
+          tabIndex={0}
+        >
           {result.messages.map((msg, i) => (
             <div
               key={i}

--- a/src/features/settings/components/SettingsDialog.tsx
+++ b/src/features/settings/components/SettingsDialog.tsx
@@ -53,6 +53,7 @@ function TemplateEditor({ label, value, onChange }: TemplateEditorProps) {
       </div>
       <textarea
         aria-label={label}
+        wrap="off"
         value={value}
         onChange={(event) => onChange(event.target.value)}
         onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}

--- a/src/features/settings/components/SettingsDialog.tsx
+++ b/src/features/settings/components/SettingsDialog.tsx
@@ -10,6 +10,12 @@ interface SettingsDialogProps {
   onClose: () => void;
 }
 
+interface TemplateEditorProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
 const CONNECTION_SEARCH_TERMS = [
   "connection",
   "connections",
@@ -20,6 +26,43 @@ const CONNECTION_SEARCH_TERMS = [
   "profile",
   "profiles",
 ];
+
+function TemplateEditor({ label, value, onChange }: TemplateEditorProps) {
+  const [scrollTop, setScrollTop] = useState(0);
+  const lineNumbers = useMemo(
+    () =>
+      Array.from({ length: value.split("\n").length }, (_, index) => index + 1).join(
+        "\n"
+      ),
+    [value]
+  );
+
+  return (
+    <div className="grid min-h-36 w-full grid-cols-[3rem_minmax(0,1fr)] overflow-hidden rounded border border-bg-tertiary bg-bg-input focus-within:border-accent-hover focus-within:ring-1 focus-within:ring-accent-hover">
+      <div
+        aria-hidden="true"
+        data-testid="new-query-template-line-numbers"
+        className="relative overflow-hidden border-r border-bg-tertiary bg-bg-secondary font-mono text-xs leading-5 text-text-secondary"
+      >
+        <pre
+          className="m-0 select-none px-2 py-2 text-right font-mono leading-5"
+          style={{ transform: `translateY(-${scrollTop}px)` }}
+        >
+          {lineNumbers}
+        </pre>
+      </div>
+      <textarea
+        aria-label={label}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+        rows={8}
+        spellCheck={false}
+        className="min-h-36 w-full resize-y border-0 bg-bg-input px-3 py-2 font-mono text-sm leading-5 text-text-primary focus:outline-none"
+      />
+    </div>
+  );
+}
 
 export function SettingsDialog({ open: isOpen, onClose }: SettingsDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -231,13 +274,10 @@ export function SettingsDialog({ open: isOpen, onClose }: SettingsDialogProps) {
                         <span>Enabled</span>
                       </label>
                     ) : (
-                      <textarea
-                        aria-label={setting.title}
+                      <TemplateEditor
+                        label={setting.title}
                         value={settings.queryEditor.newQueryTemplate}
-                        onChange={(event) => updateTemplate(event.target.value)}
-                        rows={8}
-                        spellCheck={false}
-                        className="min-h-36 w-full resize-y rounded border border-bg-tertiary bg-bg-input px-3 py-2 font-mono text-sm text-text-primary focus:border-accent-hover focus:outline-none focus:ring-1 focus:ring-accent-hover"
+                        onChange={updateTemplate}
                       />
                     )}
                   </section>

--- a/src/features/settings/settingsSchema.ts
+++ b/src/features/settings/settingsSchema.ts
@@ -3,6 +3,7 @@ import type { AppSettings, SettingDefinition } from "./types";
 export const DEFAULT_NEW_QUERY_TEMPLATE = "\n{{cursor}}\n";
 export const LEGACY_DEFAULT_NEW_QUERY_TEMPLATE =
   "\n".repeat(30) + "{{cursor}}";
+export const NEW_QUERY_TEMPLATE_MIGRATION_VERSION = 1;
 
 export const defaultSettings: AppSettings = {
   explorer: {
@@ -13,6 +14,7 @@ export const defaultSettings: AppSettings = {
   },
   queryEditor: {
     newQueryTemplate: DEFAULT_NEW_QUERY_TEMPLATE,
+    newQueryTemplateMigrationVersion: NEW_QUERY_TEMPLATE_MIGRATION_VERSION,
   },
   connections: {
     colorProfiles: [],

--- a/src/features/settings/settingsSchema.ts
+++ b/src/features/settings/settingsSchema.ts
@@ -1,5 +1,9 @@
 import type { AppSettings, SettingDefinition } from "./types";
 
+export const DEFAULT_NEW_QUERY_TEMPLATE = "\n{{cursor}}\n";
+export const LEGACY_DEFAULT_NEW_QUERY_TEMPLATE =
+  "\n".repeat(30) + "{{cursor}}";
+
 export const defaultSettings: AppSettings = {
   explorer: {
     groupTablesBySchema: true,
@@ -8,7 +12,7 @@ export const defaultSettings: AppSettings = {
     persistQueryTabs: true,
   },
   queryEditor: {
-    newQueryTemplate: "\n".repeat(30) + "{{cursor}}",
+    newQueryTemplate: DEFAULT_NEW_QUERY_TEMPLATE,
   },
   connections: {
     colorProfiles: [],

--- a/src/features/settings/store/settingsStore.ts
+++ b/src/features/settings/store/settingsStore.ts
@@ -87,6 +87,10 @@ export function loadSettings(): AppSettings {
     const migrationVersion = readMigrationVersion(
       readProperty(queryEditor, "newQueryTemplateMigrationVersion")
     );
+    const persistedMigrationVersion = Math.max(
+      migrationVersion,
+      NEW_QUERY_TEMPLATE_MIGRATION_VERSION
+    );
 
     const settings: AppSettings = {
       explorer: {
@@ -107,7 +111,7 @@ export function loadSettings(): AppSettings {
           defaultSettings.queryEditor.newQueryTemplate,
           migrationVersion
         ),
-        newQueryTemplateMigrationVersion: NEW_QUERY_TEMPLATE_MIGRATION_VERSION,
+        newQueryTemplateMigrationVersion: persistedMigrationVersion,
       },
       connections: {
         colorProfiles: readColorProfiles(readProperty(connections, "colorProfiles")),

--- a/src/features/settings/store/settingsStore.ts
+++ b/src/features/settings/store/settingsStore.ts
@@ -70,6 +70,33 @@ function readProperty(value: unknown, property: string): unknown {
   return Reflect.get(value, property);
 }
 
+function saveNewQueryTemplateMigration(
+  storedSettings: object,
+  storedQueryEditor: unknown,
+  queryEditor: AppSettings["queryEditor"]
+): void {
+  try {
+    const existingQueryEditor =
+      typeof storedQueryEditor === "object" &&
+      storedQueryEditor !== null &&
+      !Array.isArray(storedQueryEditor)
+        ? storedQueryEditor
+        : {};
+    window.localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        ...storedSettings,
+        queryEditor: {
+          ...existingQueryEditor,
+          ...queryEditor,
+        },
+      })
+    );
+  } catch (cause) {
+    console.error("Failed to save settings:", cause);
+  }
+}
+
 export function loadSettings(): AppSettings {
   try {
     const storedValue = window.localStorage.getItem(SETTINGS_STORAGE_KEY);
@@ -119,7 +146,7 @@ export function loadSettings(): AppSettings {
     };
 
     if (migrationVersion < NEW_QUERY_TEMPLATE_MIGRATION_VERSION) {
-      saveSettings(settings);
+      saveNewQueryTemplateMigration(parsed, queryEditor, settings.queryEditor);
     }
 
     return settings;

--- a/src/features/settings/store/settingsStore.ts
+++ b/src/features/settings/store/settingsStore.ts
@@ -3,6 +3,7 @@ import type { AppSettings, CustomColorProfile } from "../types";
 import {
   defaultSettings,
   LEGACY_DEFAULT_NEW_QUERY_TEMPLATE,
+  NEW_QUERY_TEMPLATE_MIGRATION_VERSION,
 } from "../settingsSchema";
 import {
   BUILT_IN_COLOR_PROFILES,
@@ -35,9 +36,24 @@ function readString(value: unknown, fallback: string): string {
   return typeof value === "string" ? value : fallback;
 }
 
-function readNewQueryTemplate(value: unknown, fallback: string): string {
+function readMigrationVersion(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : 0;
+}
+
+function readNewQueryTemplate(
+  value: unknown,
+  fallback: string,
+  migrationVersion: number
+): string {
   const template = readString(value, fallback);
-  if (template === LEGACY_DEFAULT_NEW_QUERY_TEMPLATE) return fallback;
+  if (
+    migrationVersion < NEW_QUERY_TEMPLATE_MIGRATION_VERSION &&
+    template === LEGACY_DEFAULT_NEW_QUERY_TEMPLATE
+  ) {
+    return fallback;
+  }
   return hasAtMostOneCursorMarker(template) ? template : fallback;
 }
 
@@ -68,8 +84,11 @@ export function loadSettings(): AppSettings {
     const workspace = readProperty(parsed, "workspace");
     const queryEditor = readProperty(parsed, "queryEditor");
     const connections = readProperty(parsed, "connections");
+    const migrationVersion = readMigrationVersion(
+      readProperty(queryEditor, "newQueryTemplateMigrationVersion")
+    );
 
-    return {
+    const settings: AppSettings = {
       explorer: {
         groupTablesBySchema: readBoolean(
           readProperty(explorer, "groupTablesBySchema"),
@@ -85,13 +104,21 @@ export function loadSettings(): AppSettings {
       queryEditor: {
         newQueryTemplate: readNewQueryTemplate(
           readProperty(queryEditor, "newQueryTemplate"),
-          defaultSettings.queryEditor.newQueryTemplate
+          defaultSettings.queryEditor.newQueryTemplate,
+          migrationVersion
         ),
+        newQueryTemplateMigrationVersion: NEW_QUERY_TEMPLATE_MIGRATION_VERSION,
       },
       connections: {
         colorProfiles: readColorProfiles(readProperty(connections, "colorProfiles")),
       },
     };
+
+    if (migrationVersion < NEW_QUERY_TEMPLATE_MIGRATION_VERSION) {
+      saveSettings(settings);
+    }
+
+    return settings;
   } catch (cause) {
     console.warn("Failed to load settings:", cause);
     return defaultSettings;

--- a/src/features/settings/store/settingsStore.ts
+++ b/src/features/settings/store/settingsStore.ts
@@ -1,6 +1,9 @@
 import { create } from "zustand";
 import type { AppSettings, CustomColorProfile } from "../types";
-import { defaultSettings } from "../settingsSchema";
+import {
+  defaultSettings,
+  LEGACY_DEFAULT_NEW_QUERY_TEMPLATE,
+} from "../settingsSchema";
 import {
   BUILT_IN_COLOR_PROFILES,
   normalizeCustomColorProfiles,
@@ -34,6 +37,7 @@ function readString(value: unknown, fallback: string): string {
 
 function readNewQueryTemplate(value: unknown, fallback: string): string {
   const template = readString(value, fallback);
+  if (template === LEGACY_DEFAULT_NEW_QUERY_TEMPLATE) return fallback;
   return hasAtMostOneCursorMarker(template) ? template : fallback;
 }
 

--- a/src/features/settings/types.ts
+++ b/src/features/settings/types.ts
@@ -33,6 +33,7 @@ export interface AppSettings {
   };
   queryEditor: {
     newQueryTemplate: string;
+    newQueryTemplateMigrationVersion: number;
   };
   connections: {
     colorProfiles: CustomColorProfile[];

--- a/tests/frontend/connectionAppearanceDom.test.tsx
+++ b/tests/frontend/connectionAppearanceDom.test.tsx
@@ -57,7 +57,7 @@ function resetStores(profiles: CustomColorProfile[] = []) {
     settings: {
       explorer: { groupTablesBySchema: true },
       workspace: { persistQueryTabs: true },
-      queryEditor: { newQueryTemplate: "\n".repeat(30) + "{{cursor}}" },
+      queryEditor: { newQueryTemplate: "\n{{cursor}}\n" },
       connections: { colorProfiles: profiles },
     },
   });
@@ -698,7 +698,7 @@ describe("SettingsDialog", () => {
       JSON.stringify({ queryEditor: { newQueryTemplate: null } })
     );
     expect(loadSettings().queryEditor.newQueryTemplate).toBe(
-      "\n".repeat(30) + "{{cursor}}"
+      "\n{{cursor}}\n"
     );
 
     const whitespaceTemplate = "  SELECT 1;  \n\n";
@@ -719,8 +719,16 @@ describe("SettingsDialog", () => {
       JSON.stringify({ queryEditor: { newQueryTemplate: "{{cursor}} SELECT {{cursor}}" } })
     );
     expect(loadSettings().queryEditor.newQueryTemplate).toBe(
-      "\n".repeat(30) + "{{cursor}}"
+      "\n{{cursor}}\n"
     );
+
+    window.localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        queryEditor: { newQueryTemplate: "\n".repeat(30) + "{{cursor}}" },
+      })
+    );
+    expect(loadSettings().queryEditor.newQueryTemplate).toBe("\n{{cursor}}\n");
   });
 
   it("rejects duplicate markers without changing settings", () => {
@@ -758,6 +766,9 @@ describe("SettingsDialog", () => {
     fireEvent.change(textarea, { target: { value: template } });
 
     expect((textarea as HTMLTextAreaElement).value).toBe(template);
+    expect(
+      screen.getByTestId("new-query-template-line-numbers").textContent
+    ).toContain("1\n2\n3");
     expect(useSettingsStore.getState().settings.queryEditor.newQueryTemplate).toBe(
       template
     );

--- a/tests/frontend/connectionAppearanceDom.test.tsx
+++ b/tests/frontend/connectionAppearanceDom.test.tsx
@@ -57,7 +57,10 @@ function resetStores(profiles: CustomColorProfile[] = []) {
     settings: {
       explorer: { groupTablesBySchema: true },
       workspace: { persistQueryTabs: true },
-      queryEditor: { newQueryTemplate: "\n{{cursor}}\n" },
+      queryEditor: {
+        newQueryTemplate: "\n{{cursor}}\n",
+        newQueryTemplateMigrationVersion: 1,
+      },
       connections: { colorProfiles: profiles },
     },
   });
@@ -729,6 +732,29 @@ describe("SettingsDialog", () => {
       })
     );
     expect(loadSettings().queryEditor.newQueryTemplate).toBe("\n{{cursor}}\n");
+
+    const storedMigration = JSON.parse(
+      window.localStorage.getItem(SETTINGS_STORAGE_KEY) ?? "{}"
+    );
+    expect(storedMigration.queryEditor).toEqual({
+      newQueryTemplate: "\n{{cursor}}\n",
+      newQueryTemplateMigrationVersion: 1,
+    });
+
+    const migratedSettings = loadSettings();
+    window.localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        ...migratedSettings,
+        queryEditor: {
+          ...migratedSettings.queryEditor,
+          newQueryTemplate: "\n".repeat(30) + "{{cursor}}",
+        },
+      })
+    );
+    expect(loadSettings().queryEditor.newQueryTemplate).toBe(
+      "\n".repeat(30) + "{{cursor}}"
+    );
   });
 
   it("rejects duplicate markers without changing settings", () => {
@@ -766,6 +792,7 @@ describe("SettingsDialog", () => {
     fireEvent.change(textarea, { target: { value: template } });
 
     expect((textarea as HTMLTextAreaElement).value).toBe(template);
+    expect((textarea as HTMLTextAreaElement).wrap).toBe("off");
     expect(
       screen.getByTestId("new-query-template-line-numbers").textContent
     ).toContain("1\n2\n3");

--- a/tests/frontend/connectionAppearanceDom.test.tsx
+++ b/tests/frontend/connectionAppearanceDom.test.tsx
@@ -755,6 +755,18 @@ describe("SettingsDialog", () => {
     expect(loadSettings().queryEditor.newQueryTemplate).toBe(
       "\n".repeat(30) + "{{cursor}}"
     );
+
+    window.localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        ...migratedSettings,
+        queryEditor: {
+          ...migratedSettings.queryEditor,
+          newQueryTemplateMigrationVersion: 2,
+        },
+      })
+    );
+    expect(loadSettings().queryEditor.newQueryTemplateMigrationVersion).toBe(2);
   });
 
   it("rejects duplicate markers without changing settings", () => {

--- a/tests/frontend/connectionAppearanceDom.test.tsx
+++ b/tests/frontend/connectionAppearanceDom.test.tsx
@@ -728,7 +728,11 @@ describe("SettingsDialog", () => {
     window.localStorage.setItem(
       SETTINGS_STORAGE_KEY,
       JSON.stringify({
-        queryEditor: { newQueryTemplate: "\n".repeat(30) + "{{cursor}}" },
+        futureSetting: { enabled: true },
+        queryEditor: {
+          futureQueryEditorSetting: "keep this",
+          newQueryTemplate: "\n".repeat(30) + "{{cursor}}",
+        },
       })
     );
     expect(loadSettings().queryEditor.newQueryTemplate).toBe("\n{{cursor}}\n");
@@ -737,9 +741,11 @@ describe("SettingsDialog", () => {
       window.localStorage.getItem(SETTINGS_STORAGE_KEY) ?? "{}"
     );
     expect(storedMigration.queryEditor).toEqual({
+      futureQueryEditorSetting: "keep this",
       newQueryTemplate: "\n{{cursor}}\n",
       newQueryTemplateMigrationVersion: 1,
     });
+    expect(storedMigration.futureSetting).toEqual({ enabled: true });
 
     const migratedSettings = loadSettings();
     window.localStorage.setItem(

--- a/tests/frontend/fixtures/newQueryTemplate.tsx
+++ b/tests/frontend/fixtures/newQueryTemplate.tsx
@@ -29,7 +29,10 @@ useSettingsStore.setState({
   settings: {
     explorer: { groupTablesBySchema: true },
     workspace: { persistQueryTabs: false },
-    queryEditor: { newQueryTemplate: "\n{{cursor}}\n" },
+    queryEditor: {
+      newQueryTemplate: "\n{{cursor}}\n",
+      newQueryTemplateMigrationVersion: 1,
+    },
     connections: { colorProfiles: [] },
   },
 });

--- a/tests/frontend/fixtures/newQueryTemplate.tsx
+++ b/tests/frontend/fixtures/newQueryTemplate.tsx
@@ -16,6 +16,7 @@ interface AcceptanceFixture {
   getActiveTab: () => QueryTab | undefined;
   getActiveSql: () => string;
   isActiveTabDirty: () => boolean;
+  showMessages: () => void;
 }
 
 declare global {
@@ -28,7 +29,7 @@ useSettingsStore.setState({
   settings: {
     explorer: { groupTablesBySchema: true },
     workspace: { persistQueryTabs: false },
-    queryEditor: { newQueryTemplate: "\n".repeat(30) + "{{cursor}}" },
+    queryEditor: { newQueryTemplate: "\n{{cursor}}\n" },
     connections: { colorProfiles: [] },
   },
 });
@@ -89,6 +90,28 @@ function AcceptanceFixtureApp() {
       isActiveTabDirty: () => {
         const state = useQueryStore.getState();
         return state.activeTabId ? state.isTabDirty(state.activeTabId) : false;
+      },
+      showMessages: () => {
+        const state = useQueryStore.getState();
+        if (!state.activeTabId) return;
+        useQueryStore.setState({
+          results: {
+            ...state.results,
+            [state.activeTabId]: {
+              resultSets: [],
+              columns: [],
+              rows: [],
+              messages: [
+                {
+                  text: "Only this query message should be selected.",
+                  severity: "info",
+                },
+              ],
+              executionTimeMs: 1,
+              totalRows: 0,
+            },
+          },
+        });
       },
     };
 

--- a/tests/frontend/fixtures/objectExplorerStyles.tsx
+++ b/tests/frontend/fixtures/objectExplorerStyles.tsx
@@ -26,7 +26,10 @@ useSettingsStore.setState({
   settings: {
     explorer: { groupTablesBySchema: true },
     workspace: { persistQueryTabs: true },
-    queryEditor: { newQueryTemplate: "\n{{cursor}}\n" },
+    queryEditor: {
+      newQueryTemplate: "\n{{cursor}}\n",
+      newQueryTemplateMigrationVersion: 1,
+    },
     connections: { colorProfiles: [nightProfile, boundaryProfile] },
   },
 });

--- a/tests/frontend/fixtures/objectExplorerStyles.tsx
+++ b/tests/frontend/fixtures/objectExplorerStyles.tsx
@@ -26,7 +26,7 @@ useSettingsStore.setState({
   settings: {
     explorer: { groupTablesBySchema: true },
     workspace: { persistQueryTabs: true },
-    queryEditor: { newQueryTemplate: "\n".repeat(30) + "{{cursor}}" },
+    queryEditor: { newQueryTemplate: "\n{{cursor}}\n" },
     connections: { colorProfiles: [nightProfile, boundaryProfile] },
   },
 });

--- a/tests/frontend/newQueryTemplate.test.ts
+++ b/tests/frontend/newQueryTemplate.test.ts
@@ -14,12 +14,12 @@ test("preserves whitespace around a cursor marker", () => {
   });
 });
 
-test("places the default template cursor on line 31", () => {
-  const template = "\n".repeat(30) + "{{cursor}}";
+test("places the default template cursor on line 2 of 3", () => {
+  const template = "\n{{cursor}}\n";
 
   assert.deepEqual(parseNewQueryTemplate(template), {
-    sql: "\n".repeat(30),
-    cursorOffset: 30,
+    sql: "\n\n",
+    cursorOffset: 1,
   });
 });
 

--- a/tests/frontend/newQueryTemplateBrowser.test.ts
+++ b/tests/frontend/newQueryTemplateBrowser.test.ts
@@ -12,6 +12,7 @@ const TEMPLATE = "  BEGIN TRANSACTION;\n    {{cursor}}SELECT 1;\nCOMMIT;  \n";
 const PROCESSED_TEMPLATE = "  BEGIN TRANSACTION;\n    SELECT 1;\nCOMMIT;  \n";
 const CURSOR_SENTINEL = "/* here */";
 const SCREENSHOT_PATH = join(tmpdir(), "ssmsx-new-query-template-browser.png");
+const MESSAGES_SCREENSHOT_PATH = join(tmpdir(), "ssmsx-query-messages-select-all.png");
 
 interface FixtureWindow extends Window {
   ssmsxNewQueryTemplateFixture?: {
@@ -19,10 +20,11 @@ interface FixtureWindow extends Window {
     getActiveTab: () => { initialSql?: string; title: string } | undefined;
     getActiveSql: () => string;
     isActiveTabDirty: () => boolean;
+    showMessages: () => void;
   };
 }
 
-test("new query templates preserve whitespace and place the Monaco cursor", async () => {
+test("query acceptance preserves template whitespace and scopes message selection", async () => {
   const vite = await createServer({
     configFile: false,
     root: process.cwd(),
@@ -46,7 +48,23 @@ test("new query templates preserve whitespace and place the Monaco cursor", asyn
     await page.getByRole("button", { name: "Query Editor" }).click();
     const templateControl = page.getByRole("textbox", { name: "New query template" });
     await templateControl.waitFor();
+
+    assert.equal(await templateControl.inputValue(), "\n{{cursor}}\n");
+    const lineNumbers = page.getByTestId("new-query-template-line-numbers");
+    assert.equal(await lineNumbers.innerText(), "1\n2\n3");
+
+    const dialog = page.getByRole("dialog");
+    const dialogBox = await dialog.boundingBox();
+    const controlBox = await templateControl.boundingBox();
+    assert(dialogBox && controlBox);
+    assert.ok(dialogBox.x >= 0 && dialogBox.y >= 0);
+    assert.ok(dialogBox.x + dialogBox.width <= 960 && dialogBox.y + dialogBox.height <= 720);
+    assert.ok(controlBox.width >= 350 && controlBox.height >= 140);
+    await page.screenshot({ path: SCREENSHOT_PATH });
+    assert.ok(existsSync(SCREENSHOT_PATH));
+
     await templateControl.fill(TEMPLATE);
+    assert.equal(await lineNumbers.innerText(), "1\n2\n3\n4");
 
     const storedTemplate = await page.evaluate(() => {
       const raw = window.localStorage.getItem("ssmsx.settings");
@@ -63,16 +81,6 @@ test("new query templates preserve whitespace and place the Monaco cursor", asyn
       return typeof template === "string" ? template : null;
     });
     assert.equal(storedTemplate, TEMPLATE);
-
-    const dialog = page.getByRole("dialog");
-    const dialogBox = await dialog.boundingBox();
-    const controlBox = await templateControl.boundingBox();
-    assert(dialogBox && controlBox);
-    assert.ok(dialogBox.x >= 0 && dialogBox.y >= 0);
-    assert.ok(dialogBox.x + dialogBox.width <= 960 && dialogBox.y + dialogBox.height <= 720);
-    assert.ok(controlBox.width >= 400 && controlBox.height >= 140);
-    await page.screenshot({ path: SCREENSHOT_PATH });
-    assert.ok(existsSync(SCREENSHOT_PATH));
 
     await page.getByRole("button", { name: "Close" }).click();
     await page.getByTitle(/New Query/).click();
@@ -117,6 +125,17 @@ test("new query templates preserve whitespace and place the Monaco cursor", asyn
       sql: "SELECT name FROM sys.databases;\n",
     });
 
+    await page.evaluate(() => {
+      (window as FixtureWindow).ssmsxNewQueryTemplateFixture?.showMessages();
+    });
+    const messages = page.getByRole("region", { name: "Query messages" });
+    await messages.focus();
+    await page.keyboard.press("Meta+a");
+    const selectedText = await page.evaluate(() => window.getSelection()?.toString());
+    assert.equal(selectedText, "Only this query message should be selected.\n");
+    assert.doesNotMatch(selectedText ?? "", /New query template acceptance/);
+    await page.screenshot({ path: MESSAGES_SCREENSHOT_PATH });
+    assert.ok(existsSync(MESSAGES_SCREENSHOT_PATH));
   } finally {
     await browser?.close();
     await vite.close();

--- a/tests/frontend/newQueryTemplateBrowser.test.ts
+++ b/tests/frontend/newQueryTemplateBrowser.test.ts
@@ -134,6 +134,10 @@ test("query acceptance preserves template whitespace and scopes message selectio
     const selectedText = await page.evaluate(() => window.getSelection()?.toString());
     assert.equal(selectedText, "Only this query message should be selected.\n");
     assert.doesNotMatch(selectedText ?? "", /New query template acceptance/);
+    await page.keyboard.press("Control+a");
+    const controlSelectedText = await page.evaluate(() => window.getSelection()?.toString());
+    assert.equal(controlSelectedText, "Only this query message should be selected.\n");
+    assert.doesNotMatch(controlSelectedText ?? "", /New query template acceptance/);
     await page.screenshot({ path: MESSAGES_SCREENSHOT_PATH });
     assert.ok(existsSync(MESSAGES_SCREENSHOT_PATH));
   } finally {

--- a/tests/frontend/queryUi.test.tsx
+++ b/tests/frontend/queryUi.test.tsx
@@ -518,22 +518,24 @@ describe("query results layout and resizing", () => {
     expect(separator.getAttribute("aria-valuenow")).toBe("500");
   });
 
-  it("selects only the message text with Command+A", () => {
+  it("selects only the message text with Command+A and Control+A", () => {
     render(<QueryResultsTable result={result} profile={nightProfile} tabId="query" />);
     const messagesTab = screen.getByRole("button", { name: "Messages (1)" });
     fireEvent.click(messagesTab);
     messagesTab.focus();
 
-    const keyDown = new KeyboardEvent("keydown", {
-      key: "a",
-      metaKey: true,
-      bubbles: true,
-      cancelable: true,
-    });
-    messagesTab.dispatchEvent(keyDown);
+    for (const modifier of [{ metaKey: true }, { ctrlKey: true }]) {
+      const keyDown = new KeyboardEvent("keydown", {
+        key: "a",
+        ...modifier,
+        bubbles: true,
+        cancelable: true,
+      });
+      messagesTab.dispatchEvent(keyDown);
 
-    expect(keyDown.defaultPrevented).toBe(true);
-    expect(window.getSelection()?.toString()).toBe("Completed");
+      expect(keyDown.defaultPrevented).toBe(true);
+      expect(window.getSelection()?.toString()).toBe("Completed");
+    }
   });
 
   it("cleans up a pointer resize when the result table unmounts", () => {

--- a/tests/frontend/queryUi.test.tsx
+++ b/tests/frontend/queryUi.test.tsx
@@ -88,7 +88,7 @@ function resetStores() {
     settings: {
       explorer: { groupTablesBySchema: true },
       workspace: { persistQueryTabs: true },
-      queryEditor: { newQueryTemplate: "\n".repeat(30) + "{{cursor}}" },
+      queryEditor: { newQueryTemplate: "\n{{cursor}}\n" },
       connections: { colorProfiles: [nightProfile] },
     },
   });
@@ -513,6 +513,24 @@ describe("query results layout and resizing", () => {
     fireEvent.keyDown(separator, { key: "ArrowRight" });
     expect(column?.style.width).toBe("500px");
     expect(separator.getAttribute("aria-valuenow")).toBe("500");
+  });
+
+  it("selects only the message text with Command+A", () => {
+    render(<QueryResultsTable result={result} profile={nightProfile} tabId="query" />);
+    const messagesTab = screen.getByRole("button", { name: "Messages (1)" });
+    fireEvent.click(messagesTab);
+    messagesTab.focus();
+
+    const keyDown = new KeyboardEvent("keydown", {
+      key: "a",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    messagesTab.dispatchEvent(keyDown);
+
+    expect(keyDown.defaultPrevented).toBe(true);
+    expect(window.getSelection()?.toString()).toBe("Completed");
   });
 
   it("cleans up a pointer resize when the result table unmounts", () => {

--- a/tests/frontend/queryUi.test.tsx
+++ b/tests/frontend/queryUi.test.tsx
@@ -88,7 +88,10 @@ function resetStores() {
     settings: {
       explorer: { groupTablesBySchema: true },
       workspace: { persistQueryTabs: true },
-      queryEditor: { newQueryTemplate: "\n{{cursor}}\n" },
+      queryEditor: {
+        newQueryTemplate: "\n{{cursor}}\n",
+        newQueryTemplateMigrationVersion: 1,
+      },
       connections: { colorProfiles: [nightProfile] },
     },
   });


### PR DESCRIPTION
## Summary

- I added line numbers to the new query template editor and changed the built-in template to three lines with the cursor on line 2.
- Existing installations using the old 30-line default move to the new default, while custom leading and trailing whitespace stays exactly as entered.
- Command+A in the Messages result tab now selects only the query messages instead of the whole app. Control+A works on other platforms too.

## Test plan

- `npm run test:frontend`
- `npm run build`
- Verified the template editor and Messages selection in headless Chrome screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a template editor with synchronized line numbers, scrolling, and monospace editing.
  * Added keyboard selection for query messages without affecting result-grid selection.
  * Added accessibility labels and visible focus styling to the messages area.

* **Improvements**
  * Updated the default new-query template for a cleaner starting experience.
  * Existing legacy templates are automatically migrated to the current default.
  * Improved query editor layout and cursor positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->